### PR TITLE
fix: improve dividend chart layouts

### DIFF
--- a/src/components/DividendChart.jsx
+++ b/src/components/DividendChart.jsx
@@ -5,19 +5,17 @@ import {
   CategoryScale,
   LinearScale,
   BarElement,
-  RadialLinearScale,
-  ArcElement,
   Title,
   Tooltip,
   Legend,
 } from 'chart.js';
-import { Bar, PolarArea } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { DollarSign, TrendingUp, Calendar } from 'lucide-react';
 import KPICard from './KPICard';
 import GoalTracker from './GoalTracker';
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, RadialLinearScale, ArcElement, Title, Tooltip, Legend, ChartDataLabels);
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, ChartDataLabels);
 
 const MONTH_LABELS = [
   '1월', '2월', '3월', '4월', '5월', '6월',
@@ -223,10 +221,9 @@ function DividendChart() {
           }],
         });
 
-        // Stock Chart (Polar Area)
         let stockArr = Object.entries(stockMap);
         stockArr.sort((a, b) => b[1] - a[1]);
-        stockArr = stockArr.slice(0, 10); // Limit to top 10 for Polar Area
+        stockArr = stockArr.slice(0, 10);
 
         const colorPalette = [
           'rgba(255, 99, 132, 0.7)',
@@ -247,7 +244,10 @@ function DividendChart() {
             label: '종목별 배당금',
             data: stockArr.map(([, value]) => value),
             backgroundColor: colorPalette,
+            borderColor: colorPalette.map(color => color.replace('0.7', '1')),
             borderWidth: 1,
+            borderRadius: 4,
+            barThickness: 22,
           }]
         });
 
@@ -264,6 +264,14 @@ function DividendChart() {
   const chartOptions = (title, unit = '₩') => ({
     responsive: true,
     maintainAspectRatio: false,
+    layout: {
+      padding: {
+        top: 8,
+        right: 8,
+        bottom: 4,
+        left: 4
+      }
+    },
     plugins: {
       legend: { position: 'top', labels: { color: '#666' } },
       title: { display: true, text: title, color: '#666' },
@@ -286,6 +294,7 @@ function DividendChart() {
         color: '#666',
       },
       tooltip: {
+        yAlign: title.includes('전년 동월') ? 'bottom' : undefined,
         backgroundColor: 'rgba(0, 0, 0, 0.8)',
         titleColor: '#fff',
         bodyColor: '#fff',
@@ -307,6 +316,7 @@ function DividendChart() {
         grid: { color: 'rgba(0,0,0,0.05)' }
       },
       y: {
+        grace: title.includes('전년 동월') ? '20%' : undefined,
         ticks: { color: '#666' },
         grid: { color: 'rgba(0,0,0,0.05)' }
       }
@@ -338,37 +348,53 @@ function DividendChart() {
       </div>
 
       <div style={{ display: 'flex', gap: '24px', flexWrap: 'wrap' }}>
-        <div className="card" style={{ flex: 1, minWidth: '320px', height: '400px' }}>
+        <div className="card" style={{ flex: 1, minWidth: 'min(320px, 100%)', height: '400px' }}>
           {monthChart ? <Bar data={monthChart} options={chartOptions('월별 배당금 (연도별 비교)')} /> : <div>데이터 불러오는 중...</div>}
         </div>
 
         {comparisonChart && (
-          <div className="card" style={{ flex: 1, minWidth: '320px', height: '400px' }}>
+          <div className="card" style={{ flex: 1, minWidth: 'min(320px, 100%)', height: '400px' }}>
             <Bar data={comparisonChart} options={chartOptions(`전년 동월 대비 증감 (${comparisonChart.currentYear} vs ${comparisonChart.prevYear})`)} />
           </div>
         )}
       </div>
 
       <div style={{ display: 'flex', gap: '24px', flexWrap: 'wrap' }}>
-        <div className="card" style={{ flex: 1, minWidth: '320px', height: '400px' }}>
+        <div className="card" style={{ flex: 1, minWidth: 'min(320px, 100%)', height: '400px' }}>
           {yearChart ? <Bar data={yearChart} options={chartOptions('연도별 배당금 합계')} /> : <div>데이터 불러오는 중...</div>}
         </div>
 
-        <div className="card" style={{ flex: 1, minWidth: '320px', height: '400px' }}>
+        <div className="card" style={{ flex: 1, minWidth: 'min(320px, 100%)', height: '400px' }}>
           {accountChart ? <Bar data={accountChart} options={chartOptions('계좌별 배당금 합계')} /> : <div>데이터 불러오는 중...</div>}
         </div>
       </div>
 
-      <div className="card" style={{ height: '500px', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <div className="card" style={{ height: '520px', display: 'flex', flexDirection: 'column' }}>
         <h4 style={{ margin: '0 0 20px 0', color: '#666' }}>종목별 배당금 (Top 10)</h4>
-        <div style={{ flex: 1, width: '100%', maxWidth: '500px', position: 'relative' }}>
+        <div style={{ flex: 1, width: '100%', minHeight: 0, position: 'relative' }}>
           {stockChart ? (
-            <PolarArea data={stockChart} options={{
+            <Bar data={stockChart} options={{
+              indexAxis: 'y',
               responsive: true,
               maintainAspectRatio: false,
+              layout: {
+                padding: {
+                  top: 8,
+                  right: 64,
+                  bottom: 4,
+                  left: 4
+                }
+              },
               plugins: {
-                legend: { position: 'right', labels: { color: '#666' } },
-                datalabels: { display: false },
+                legend: { display: false },
+                datalabels: {
+                  anchor: 'end',
+                  align: 'right',
+                  clamp: true,
+                  color: '#666',
+                  formatter: (value) => `₩${Math.round(value).toLocaleString()}`,
+                  font: { weight: 'bold', size: 11 }
+                },
                 tooltip: {
                   callbacks: {
                     label: (context) => {
@@ -379,9 +405,23 @@ function DividendChart() {
                 }
               },
               scales: {
-                r: {
-                  ticks: { display: false }, // Hide radial ticks for cleaner look
+                x: {
+                  beginAtZero: true,
+                  ticks: {
+                    color: '#666',
+                    callback: (value) => `₩${Number(value).toLocaleString()}`
+                  },
                   grid: { color: 'rgba(0,0,0,0.05)' }
+                },
+                y: {
+                  ticks: {
+                    color: '#666',
+                    callback: function(value) {
+                      const label = this.getLabelForValue(value);
+                      return label.length > 20 ? `${label.slice(0, 20)}...` : label;
+                    }
+                  },
+                  grid: { display: false }
                 }
               }
             }} />

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -4,7 +4,10 @@ import { supabase } from '../api/supabaseClient';
 
 function getToday() {
   const d = new Date();
-  return d.toISOString().slice(0, 10);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const date = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${date}`;
 }
 
 function formatAmount(amount, currency) {
@@ -118,7 +121,7 @@ function DividendForm() {
     };
     await insertDividend(payload);
     alert('배당금이 등록되었습니다!');
-    setForm({ account_name: '', stock: '', dividend_amount: '', payment_date: '', currency: 'KRW' });
+    setForm({ account_name: '', stock: '', dividend_amount: '', payment_date: getToday(), currency: 'KRW' });
     setCustomStock('');
   };
 

--- a/src/components/DividendForm.test.jsx
+++ b/src/components/DividendForm.test.jsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import DividendForm from './DividendForm';
+import insertDividend from '../api/insertDividend';
+
+jest.mock('../api/insertDividend', () => jest.fn(() => Promise.resolve({ success: true })));
+
+jest.mock('../api/supabaseClient', () => ({
+  supabase: {
+    from: () => ({
+      select: (columns) => {
+        if (columns === '*') {
+          return {
+            order: () => ({
+              limit: () => Promise.resolve({ data: [], error: null })
+            })
+          };
+        }
+
+        return Promise.resolve({
+          data: [
+            {
+              account_name: 'IRP',
+              company_name: '삼성전자',
+              payment_date: '2026-07-20'
+            }
+          ],
+          error: null
+        });
+      }
+    })
+  }
+}));
+
+test('keeps payment date set to today after submitting a dividend', async () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date(2026, 6, 24, 9, 0, 0));
+  const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+  try {
+    render(<DividendForm />);
+
+    fireEvent.change(await screen.findByLabelText(/계좌명/i), { target: { value: 'IRP' } });
+    fireEvent.change(screen.getByLabelText(/종목명/i), { target: { value: '삼성전자' } });
+    fireEvent.change(screen.getByPlaceholderText('금액'), { target: { value: '12000' } });
+
+    const dateInput = document.querySelector('input[name="date"]');
+    fireEvent.change(dateInput, { target: { value: '2026-01-15' } });
+
+    fireEvent.click(screen.getByRole('button', { name: '등록' }));
+
+    await waitFor(() => expect(insertDividend).toHaveBeenCalled());
+    await waitFor(() => expect(dateInput).toHaveValue('2026-07-24'));
+  } finally {
+    alertSpy.mockRestore();
+    jest.useRealTimers();
+  }
+});

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -121,7 +121,14 @@ function Layout({ children, currentPage, setPage }) {
 
     if (isMobile) {
         return (
-            <div style={{ paddingBottom: '70px', minHeight: '100vh', background: 'var(--bg-primary)' }}>
+            <div style={{
+                display: 'grid',
+                gridTemplateRows: 'auto minmax(0, 1fr) auto',
+                minHeight: '100dvh',
+                maxHeight: '100dvh',
+                overflow: 'hidden',
+                background: 'var(--bg-primary)'
+            }}>
                 {/* Mobile Header */}
                 <div style={{
                     padding: '16px',
@@ -130,8 +137,6 @@ function Layout({ children, currentPage, setPage }) {
                     display: 'flex',
                     justifyContent: 'space-between',
                     alignItems: 'center',
-                    position: 'sticky',
-                    top: 0,
                     zIndex: 100
                 }}>
                     <h3 style={{ margin: 0 }}>Dividash</h3>
@@ -147,21 +152,17 @@ function Layout({ children, currentPage, setPage }) {
                 </div>
 
                 {/* Content */}
-                <main style={{ padding: '16px' }}>
+                <main style={{ padding: '16px', minHeight: 0, overflowY: 'auto' }}>
                     {children}
                 </main>
 
                 {/* Mobile Bottom Tab */}
                 <div style={{
-                    position: 'fixed',
-                    bottom: 0,
-                    left: 0,
-                    right: 0,
                     backgroundColor: 'var(--bg-secondary)',
                     borderTop: '1px solid var(--border-color)',
                     display: 'flex',
                     justifyContent: 'space-around',
-                    padding: '8px 0',
+                    padding: '8px 0 calc(8px + env(safe-area-inset-bottom))',
                     zIndex: 1000
                 }}>
                     {navItems.map(item => (

--- a/src/components/PortfolioAnalysis.jsx
+++ b/src/components/PortfolioAnalysis.jsx
@@ -189,35 +189,45 @@ function PortfolioAnalysis() {
 
             {/* Sector Chart */}
             <div className="card" style={{ display: 'flex', gap: '24px', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center' }}>
-                <div style={{ flex: '0 0 auto', width: '100%', maxWidth: '380px', height: '240px', position: 'relative' }}>
-                    <h4 style={{ textAlign: 'center', marginBottom: '10px' }}>섹터별 배당 비중</h4>
-                    <Doughnut
-                        data={sectorChartData}
-                        options={{
-                            responsive: true,
-                            maintainAspectRatio: false,
-                            plugins: {
-                                legend: { position: 'right', labels: { boxWidth: 12, font: { size: 10 } } },
-                                tooltip: {
-                                    callbacks: {
-                                        label: (context) => {
-                                            const label = context.label || '';
-                                            const value = context.raw;
-                                            return ` ${label}: ₩${Math.round(value).toLocaleString()}`;
-                                        }
+                <div style={{ flex: '0 1 520px', width: '100%', minWidth: 'min(320px, 100%)' }}>
+                    <h4 style={{ textAlign: 'center', margin: '0 0 16px 0' }}>섹터별 배당 비중</h4>
+                    <div style={{ width: '100%', height: '360px', position: 'relative' }}>
+                        <Doughnut
+                            data={sectorChartData}
+                            options={{
+                                responsive: true,
+                                maintainAspectRatio: false,
+                                layout: {
+                                    padding: {
+                                        top: 12,
+                                        right: 16,
+                                        bottom: 12,
+                                        left: 16
                                     }
                                 },
-                                datalabels: {
-                                    color: '#fff',
-                                    formatter: (value, ctx) => {
-                                        const dataset = ctx.chart.data.datasets[0];
-                                        const total = dataset.data.reduce((acc, curr) => acc + curr, 0);
-                                        return ((value / total) * 100).toFixed(1) + '%';
+                                plugins: {
+                                    legend: { position: 'right', labels: { boxWidth: 12, font: { size: 11 }, color: '#666' } },
+                                    tooltip: {
+                                        callbacks: {
+                                            label: (context) => {
+                                                const label = context.label || '';
+                                                const value = context.raw;
+                                                return ` ${label}: ₩${Math.round(value).toLocaleString()}`;
+                                            }
+                                        }
+                                    },
+                                    datalabels: {
+                                        color: '#fff',
+                                        formatter: (value, ctx) => {
+                                            const dataset = ctx.chart.data.datasets[0];
+                                            const total = dataset.data.reduce((acc, curr) => acc + curr, 0);
+                                            return ((value / total) * 100).toFixed(1) + '%';
+                                        }
                                     }
                                 }
-                            }
-                        }}
-                    />
+                            }}
+                        />
+                    </div>
                 </div>
                 <div style={{ flex: 1, minWidth: '250px', padding: '16px' }}>
                     <h4 style={{ display: 'flex', alignItems: 'center', gap: '8px' }}><PieChart size={18} /> 포트폴리오 분석</h4>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -43,6 +43,8 @@ body {
 
 /* Card Style Utility */
 .card {
+  box-sizing: border-box;
+  max-width: 100%;
   background-color: var(--bg-secondary);
   border-radius: 12px;
   box-shadow: var(--card-shadow);


### PR DESCRIPTION
## Summary
- Add internal headroom to the YoY monthly comparison chart so the May tooltip/data label stays inside the chart area
- Replace the stock dividend visibility chart with a horizontal bar chart and improve labels
- Give the portfolio doughnut chart a dedicated wrapper so it no longer overflows
- Keep manual-entry payment date on today's local date after submit
- Adjust the mobile layout shell so the bottom nav does not overlay dashboard charts

## Verification
- CI=true npm test -- --watchAll=false
- npm run build
- Local dev server served on Tailscale-accessible host: http://100.86.19.42:3000
- Browser QA confirmed the YoY chart has internal top headroom for the May value