### PR TITLE
fix: compare dividend KPIs through same month

### DIFF
--- a/llm-wiki/raw/2026-08-09-kpi-ytd-comparison.md
+++ b/llm-wiki/raw/2026-08-09-kpi-ytd-comparison.md
@@ -1,0 +1,17 @@
+# 2026-08-09 KPI YTD comparison change
+
+- Changed file: `src/components/DividendChart.jsx`
+- New helper: `src/utils/dividendKpi.js`
+- Regression test: `src/utils/dividendKpi.test.js`
+
+## Behavior
+
+The `올해 누적 배당금` KPI now sums January through the current month of the current year. Its YoY change compares that value with January through the same month of the previous year. The monthly average uses the elapsed-month count for the same current-year YTD range.
+
+The monthly comparison chart already limits displayed comparison bars through the current month and remains unchanged.
+
+## Verification
+
+- Targeted Jest regression tests: 2 passed
+- Production build: passed
+- Warning: Browserslist `caniuse-lite` data is stale; unrelated to this change

--- a/llm-wiki/raw/sources.md
+++ b/llm-wiki/raw/sources.md
@@ -34,3 +34,11 @@
 - Captured: 2026-08-08
 - Scope: default branch, merge settings, repository policy files, observed PR convention
 - Status: point-in-time; GitHub settings require revalidation before publish
+
+## S005 - YTD KPI Comparison Change
+
+- Type: local code change and regression-test snapshot
+- Snapshot: [2026-08-09-kpi-ytd-comparison.md](./2026-08-09-kpi-ytd-comparison.md)
+- Captured: 2026-08-09
+- Scope: Dashboard cumulative-dividend KPI and same-month prior-year comparison
+- Status: active

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -38,3 +38,9 @@
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.
 - secret, 개인정보, 실제 계좌번호 incident에서는 immutable·append-only 규칙보다 현재 tree 제거, credential 회전, 승인된 history remediation을 우선하도록 예외 절차를 추가했다.
 - 루트 agent 정책과 raw 안내 문서를 같은 규칙으로 정렬했다.
+
+## [2026-08-09] update | YTD dividend KPI comparison
+
+- `올해 누적 배당금` KPI를 현재 월까지의 올해 누적으로 변경했다.
+- 전년 비교 기준을 작년 전체 연도에서 작년 같은 월까지의 누적으로 변경했다.
+- `src/utils/dividendKpi.js`와 회귀 테스트를 추가하고 S005에 기록했다.

--- a/llm-wiki/wiki/overview.md
+++ b/llm-wiki/wiki/overview.md
@@ -2,8 +2,8 @@
 title: DiviDash Overview
 type: overview
 status: current
-updated: 2026-08-06
-source_refs: [S002]
+updated: 2026-08-09
+source_refs: [S002, S005]
 tags: [product, navigation, react]
 ---
 
@@ -15,7 +15,7 @@ DiviDash는 인증된 사용자가 배당금 내역을 입력하고, 월·연·�
 
 [`Layout.jsx`](../../src/components/Layout.jsx)는 여섯 개의 상위 navigation surface를 제공한다.
 
-1. 대시보드: KPI와 월별·연도별·계좌별·종목별 시각화
+1. 대시보드: KPI와 월별·연도별·계좌별·종목별 시각화. 올해 누적 KPI의 전년 비교는 작년 같은 월까지의 누적값을 사용한다.
 2. 캘린더: 지급일 중심의 배당 내역 탐색
 3. 포트폴리오: ticker metadata와 배당 데이터를 결합한 섹터 분석
 4. 시뮬레이터: 월 적립액, 예상 수익률, 배당 성장률, 재투자 설정 기반 장기 추정

--- a/src/components/DividendChart.jsx
+++ b/src/components/DividendChart.jsx
@@ -14,6 +14,7 @@ import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { DollarSign, TrendingUp, Calendar } from 'lucide-react';
 import KPICard from './KPICard';
 import GoalTracker from './GoalTracker';
+import { calculateYtdKpi } from '../utils/dividendKpi';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend, ChartDataLabels);
 
@@ -109,23 +110,18 @@ function DividendChart() {
         const currentYear = today.getFullYear();
         const currentMonth = today.getMonth(); // 0-indexed
 
-        const currentYearTotal = yearMap[currentYear] || 0;
-        const prevYearTotal = yearMap[currentYear - 1] || 0;
         const currentMonthAmount = monthYearMap[currentYear] ? monthYearMap[currentYear][currentMonth] : 0;
-
-        // YoY Growth calculation
-        let growth = 0;
-        if (prevYearTotal > 0) {
-          growth = ((currentYearTotal - prevYearTotal) / prevYearTotal * 100).toFixed(1);
-        }
-
-        const monthlyAvg = currentMonth >= 0 ? Math.round(currentYearTotal / (currentMonth + 1)) : 0;
+        const {
+          currentYearTotal,
+          yoyGrowth,
+          monthlyAverage: monthlyAvg,
+        } = calculateYtdKpi(monthYearMap, currentYear, currentMonth);
 
         setKpiData({
           currentMonth: currentMonthAmount,
           currentYearTotal,
           monthlyAverage: monthlyAvg,
-          yoyGrowth: Number(growth)
+          yoyGrowth
         });
 
         const years = Object.keys(monthYearMap).sort();

--- a/src/utils/dividendKpi.js
+++ b/src/utils/dividendKpi.js
@@ -1,0 +1,23 @@
+export function calculateYtdKpi(monthYearMap, currentYear, currentMonthIndex) {
+  const monthCount = Math.max(0, Math.min(11, currentMonthIndex)) + 1;
+  const currentYearData = monthYearMap[currentYear] || [];
+  const previousYearData = monthYearMap[currentYear - 1] || [];
+
+  const currentYearTotal = currentYearData
+    .slice(0, monthCount)
+    .reduce((total, amount) => total + (Number(amount) || 0), 0);
+  const previousYearTotal = previousYearData
+    .slice(0, monthCount)
+    .reduce((total, amount) => total + (Number(amount) || 0), 0);
+
+  const yoyGrowth = previousYearTotal > 0
+    ? Number(((currentYearTotal - previousYearTotal) / previousYearTotal * 100).toFixed(1))
+    : 0;
+
+  return {
+    currentYearTotal,
+    previousYearTotal,
+    monthlyAverage: Math.round(currentYearTotal / monthCount),
+    yoyGrowth,
+  };
+}

--- a/src/utils/dividendKpi.test.js
+++ b/src/utils/dividendKpi.test.js
@@ -1,0 +1,25 @@
+import { calculateYtdKpi } from './dividendKpi';
+
+describe('calculateYtdKpi', () => {
+  test('compares current year and previous year through the same month', () => {
+    const monthYearMap = {
+      2025: [100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100],
+      2026: [200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 900, 900],
+    };
+
+    const result = calculateYtdKpi(monthYearMap, 2026, 7);
+
+    expect(result.currentYearTotal).toBe(1600);
+    expect(result.previousYearTotal).toBe(800);
+    expect(result.monthlyAverage).toBe(200);
+    expect(result.yoyGrowth).toBe(100);
+  });
+
+  test('returns zero growth when the comparable previous-year total is zero', () => {
+    const result = calculateYtdKpi({ 2026: [100, 200] }, 2026, 1);
+
+    expect(result.currentYearTotal).toBe(300);
+    expect(result.previousYearTotal).toBe(0);
+    expect(result.yoyGrowth).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Change the `올해 누적 배당금` KPI to use current-year January through the current month
- Compare against the previous year's January through the same month
- Keep monthly average and YoY growth aligned to the same YTD range
- Add regression tests and update the project LLM Wiki

## Verification
- `CI=true npm test -- --watchAll=false --runInBand`
  - 3 test suites passed
  - 4 tests passed
- `npm run build` passed
- `git diff --check` passed

## Scope
- Existing unrelated `.omo/` files were intentionally excluded.
