### PR TITLE
feat(dashboard): compare current-month dividend with prior year

### DIFF
--- a/src/components/DividendChart.jsx
+++ b/src/components/DividendChart.jsx
@@ -116,6 +116,8 @@ function DividendChart() {
           currentYearTotal,
           previousYearTotal,
           yoyGrowth,
+          previousMonthAmount,
+          monthlyYoyGrowth,
           monthlyAverage: monthlyAvg,
         } = calculateYtdKpi(monthYearMap, currentYear, currentMonth);
 
@@ -124,7 +126,9 @@ function DividendChart() {
           currentYearTotal,
           previousYearTotal,
           monthlyAverage: monthlyAvg,
-          yoyGrowth
+          yoyGrowth,
+          previousMonthAmount,
+          monthlyYoyGrowth
         });
 
         const years = Object.keys(monthYearMap).sort();
@@ -330,6 +334,10 @@ function DividendChart() {
         <KPICard
           title="이번 달 배당금"
           value={`₩ ${kpiData.currentMonth.toLocaleString()}`}
+          change={kpiData.monthlyYoyGrowth}
+          comparisonValue={kpiData.previousMonthAmount}
+          comparisonLabel="작년 동월 대비"
+          comparisonPeriodLabel="작년 동월"
           icon={DollarSign}
         />
         <KPICard

--- a/src/components/KPICard.jsx
+++ b/src/components/KPICard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function KPICard({ title, value, change, comparisonValue, format = 'text', icon: Icon }) {
+function KPICard({ title, value, change, comparisonValue, comparisonLabel = '전년 동기 대비', comparisonPeriodLabel = '작년 동기', format = 'text', icon: Icon }) {
     const hasComparison = typeof change === 'number'
         && Number.isFinite(change)
         && typeof comparisonValue === 'number'
@@ -30,8 +30,8 @@ function KPICard({ title, value, change, comparisonValue, format = 'text', icon:
                     lineHeight: 1.4
                 }}>
                     <span>
-                        전년 동기 대비 {isPositive ? '▲' : '▼'}{Math.abs(change)}%
-                        {' '}(작년 동기 ₩ {comparisonValue.toLocaleString()})
+                        {comparisonLabel} {isPositive ? '▲' : '▼'}{Math.abs(change)}%
+                        {' '}({comparisonPeriodLabel} ₩ {comparisonValue.toLocaleString()})
                     </span>
                 </div>
             )}

--- a/src/components/KPICard.test.jsx
+++ b/src/components/KPICard.test.jsx
@@ -24,4 +24,10 @@ describe('KPICard comparison', () => {
 
     expect(comparison.parentElement).toHaveStyle({ color: '#e74c3c' });
   });
+
+  test('supports a month-specific comparison label', () => {
+    render(<KPICard title="이번 달 배당금" value="₩ 2,000" change={25} comparisonValue={1600} comparisonLabel="작년 동월 대비" comparisonPeriodLabel="작년 동월" />);
+
+    expect(screen.getByText('작년 동월 대비 ▲25% (작년 동월 ₩ 1,600)')).toBeInTheDocument();
+  });
 });

--- a/src/utils/dividendKpi.js
+++ b/src/utils/dividendKpi.js
@@ -2,6 +2,11 @@ export function calculateYtdKpi(monthYearMap, currentYear, currentMonthIndex) {
   const monthCount = Math.max(0, Math.min(11, currentMonthIndex)) + 1;
   const currentYearData = monthYearMap[currentYear] || [];
   const previousYearData = monthYearMap[currentYear - 1] || [];
+  const currentMonthAmount = Number(currentYearData[currentMonthIndex]) || 0;
+  const previousMonthValue = Number(previousYearData[currentMonthIndex]);
+  const previousMonthAmount = Number.isFinite(previousMonthValue) && previousMonthValue > 0
+    ? previousMonthValue
+    : null;
 
   const currentYearTotal = currentYearData
     .slice(0, monthCount)
@@ -13,11 +18,16 @@ export function calculateYtdKpi(monthYearMap, currentYear, currentMonthIndex) {
   const yoyGrowth = previousYearTotal > 0
     ? Number(((currentYearTotal - previousYearTotal) / previousYearTotal * 100).toFixed(1))
     : null;
+  const monthlyYoyGrowth = previousMonthAmount !== null
+    ? Number(((currentMonthAmount - previousMonthAmount) / previousMonthAmount * 100).toFixed(1))
+    : null;
 
   return {
     currentYearTotal,
     previousYearTotal,
     monthlyAverage: Math.round(currentYearTotal / monthCount),
     yoyGrowth,
+    previousMonthAmount,
+    monthlyYoyGrowth,
   };
 }

--- a/src/utils/dividendKpi.test.js
+++ b/src/utils/dividendKpi.test.js
@@ -13,6 +13,8 @@ describe('calculateYtdKpi', () => {
     expect(result.previousYearTotal).toBe(800);
     expect(result.monthlyAverage).toBe(200);
     expect(result.yoyGrowth).toBe(100);
+    expect(result.previousMonthAmount).toBe(100);
+    expect(result.monthlyYoyGrowth).toBe(100);
   });
 
   test('does not calculate growth when the comparable previous-year total is zero', () => {
@@ -21,5 +23,17 @@ describe('calculateYtdKpi', () => {
     expect(result.currentYearTotal).toBe(300);
     expect(result.previousYearTotal).toBe(0);
     expect(result.yoyGrowth).toBeNull();
+    expect(result.previousMonthAmount).toBeNull();
+    expect(result.monthlyYoyGrowth).toBeNull();
+  });
+
+  test('does not compare a month that has no previous-year dividend', () => {
+    const result = calculateYtdKpi({
+      2025: [100, 0, 100],
+      2026: [200, 300, 400],
+    }, 2026, 1);
+
+    expect(result.previousMonthAmount).toBeNull();
+    expect(result.monthlyYoyGrowth).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Compare the current-month dividend KPI with the same month from the previous year.
- Show the previous-year amount and year-over-year rate using the existing KPI color and direction conventions.
- Hide the comparison when the previous-year same-month amount is unavailable.

## Validation

- `CI=true npm test -- --watchAll=false --runInBand` (4 suites, 9 tests passed)
- `npm run build` (compiled successfully)
- Playwright desktop and 375px mobile QA completed with synthetic browser-route data; no horizontal overflow observed.
- No lint or typecheck script is configured in this repository.

Closes #15