### PR TITLE
fix: match unclassified securities with verified evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm start
 ```
 
 ### 4. 데이터베이스 설정 (Supabase)
-`database/schema_update.sql` 파일을 실행하여 `tickers` 테이블을 생성하고 초기 데이터를 설정하세요. 이후 [`database/ticker_matching.sql`](./database/ticker_matching.sql)을 실행하여 원본 입력값 보존형 종목 매칭, 검증 근거, 확정·수동 확인 상태를 설정하세요. 이 매칭 migration에는 확인된 종목만 `confirmed`로 포함되며, 불확실한 입력값은 수동 확인 상태로 남습니다.
+다음 순서로 실행하세요: (1) `database/schema_update.sql`, (2) 실제 Supabase Auth owner UUID로 placeholder를 교체한 [`database/security_hardening.sql`](./database/security_hardening.sql), (3) [`database/ticker_matching.sql`](./database/ticker_matching.sql). `security_hardening.sql`은 placeholder UUID 상태로 실행하면 의도적으로 실패합니다. 마지막 matching migration은 원본 입력값 보존형 종목 매칭, 검증 근거, 확정·수동 확인 상태를 설정하며, 확인된 종목만 `confirmed`로 포함하고 불확실한 입력값은 수동 확인 상태로 남깁니다.
 
 ```sql
 -- tickers 테이블 생성 예시

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm start
 ```
 
 ### 4. 데이터베이스 설정 (Supabase)
-`database/schema_update.sql` 파일을 실행하여 `tickers` 테이블을 생성하고 초기 데이터를 설정하세요.
+`database/schema_update.sql` 파일을 실행하여 `tickers` 테이블을 생성하고 초기 데이터를 설정하세요. 이후 [`database/ticker_matching.sql`](./database/ticker_matching.sql)을 실행하여 원본 입력값 보존형 종목 매칭, 검증 근거, 확정·수동 확인 상태를 설정하세요. 이 매칭 migration에는 확인된 종목만 `confirmed`로 포함되며, 불확실한 입력값은 수동 확인 상태로 남습니다.
 
 ```sql
 -- tickers 테이블 생성 예시

--- a/database/schema_update.sql
+++ b/database/schema_update.sql
@@ -14,12 +14,6 @@ ALTER TABLE public.tickers ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Enable read access for authenticated users" ON public.tickers
     FOR SELECT TO authenticated USING (true);
 
-CREATE POLICY "Enable insert for authenticated users" ON public.tickers
-    FOR INSERT TO authenticated WITH CHECK (auth.role() = 'authenticated');
-
-CREATE POLICY "Enable update for authenticated users" ON public.tickers
-    FOR UPDATE TO authenticated USING (auth.role() = 'authenticated');
-
 -- Seed Data (Sample)
 INSERT INTO tickers (ticker, sector, industry) VALUES 
 ('AAPL', 'Technology', 'Consumer Electronics'),

--- a/database/security_hardening.sql
+++ b/database/security_hardening.sql
@@ -109,15 +109,6 @@ CREATE POLICY "tickers_select_authenticated" ON public.tickers
   FOR SELECT TO authenticated
   USING (true);
 
-CREATE POLICY "tickers_insert_authenticated" ON public.tickers
-  FOR INSERT TO authenticated
-  WITH CHECK (auth.role() = 'authenticated');
-
-CREATE POLICY "tickers_update_authenticated" ON public.tickers
-  FOR UPDATE TO authenticated
-  USING (auth.role() = 'authenticated')
-  WITH CHECK (auth.role() = 'authenticated');
-
 CREATE POLICY "user_goals_select_own" ON public.user_goals
   FOR SELECT TO authenticated
   USING (user_id = auth.uid());

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -1,3 +1,7 @@
+-- Seed ownership is explicit: only rows marked migration_seed may be refreshed by
+-- this migration. Existing rows from before managed_by was introduced default to
+-- user ownership; an unchanged full seed payload may be adopted without changing
+-- its data, while any ambiguous or edited row remains protected.
 CREATE TABLE IF NOT EXISTS public.ticker_matches (
     source_input TEXT PRIMARY KEY,
     matched_ticker TEXT,
@@ -12,6 +16,9 @@ CREATE TABLE IF NOT EXISTS public.ticker_matches (
         CONSTRAINT ticker_matches_confidence_allowed
         CHECK (confidence IN ('high', 'medium', 'low')),
     evidence TEXT NOT NULL,
+    managed_by TEXT NOT NULL DEFAULT 'user'
+        CONSTRAINT ticker_matches_managed_by_allowed
+        CHECK (managed_by IN ('migration_seed', 'user')),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     CONSTRAINT confirmed_match_requires_ticker
@@ -29,6 +36,78 @@ CREATE TABLE IF NOT EXISTS public.ticker_matches (
             AND NULLIF(BTRIM(industry), '') IS NOT NULL
     )
 );
+
+-- Supported upgrades retain source_input as the existing row key. A table that
+-- lacks it is ambiguous and must be repaired explicitly instead of guessing.
+DO $$
+DECLARE
+    source_input_attnum SMALLINT;
+BEGIN
+    SELECT attnum
+    INTO source_input_attnum
+    FROM pg_attribute
+    WHERE attrelid = 'public.ticker_matches'::regclass
+      AND attname = 'source_input'
+      AND NOT attisdropped;
+
+    IF source_input_attnum IS NULL THEN
+        RAISE EXCEPTION 'ticker_matches upgrade requires the existing source_input key column';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_index
+        WHERE indrelid = 'public.ticker_matches'::regclass
+          AND indisunique
+          AND indisvalid
+          AND indnatts = 1
+          AND indkey[0] = source_input_attnum
+    ) THEN
+        RAISE EXCEPTION 'ticker_matches upgrade requires a unique source_input key';
+    END IF;
+END $$;
+
+-- CREATE TABLE IF NOT EXISTS does not alter an existing table. These additions
+-- make the migration safe for the supported older table shape before any later
+-- constraints, policies, indexes, or seed writes refer to the columns.
+ALTER TABLE public.ticker_matches
+    ADD COLUMN IF NOT EXISTS matched_ticker TEXT,
+    ADD COLUMN IF NOT EXISTS matched_company_name TEXT,
+    ADD COLUMN IF NOT EXISTS market TEXT,
+    ADD COLUMN IF NOT EXISTS sector TEXT,
+    ADD COLUMN IF NOT EXISTS industry TEXT,
+    ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'manual_review',
+    ADD COLUMN IF NOT EXISTS confidence TEXT DEFAULT 'low',
+    ADD COLUMN IF NOT EXISTS evidence TEXT,
+    ADD COLUMN IF NOT EXISTS managed_by TEXT DEFAULT 'user',
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+
+-- Legacy rows with no evidence are not eligible for confirmation. Preserve them
+-- as review data and give them a non-empty audit note so the new NOT NULL shape
+-- can be applied without turning an unverified row into a verified match.
+UPDATE public.ticker_matches
+SET status = 'manual_review'
+WHERE status = 'confirmed'
+  AND NULLIF(BTRIM(evidence), '') IS NULL;
+
+UPDATE public.ticker_matches
+SET status = COALESCE(NULLIF(BTRIM(status), ''), 'manual_review'),
+    confidence = COALESCE(NULLIF(BTRIM(confidence), ''), 'low'),
+    evidence = COALESCE(NULLIF(BTRIM(evidence), ''), 'Legacy row requires manual verification'),
+    managed_by = COALESCE(NULLIF(BTRIM(managed_by), ''), 'user'),
+    created_at = COALESCE(created_at, NOW()),
+    updated_at = COALESCE(updated_at, NOW());
+
+ALTER TABLE public.ticker_matches
+    ALTER COLUMN source_input SET NOT NULL,
+    ALTER COLUMN status SET DEFAULT 'manual_review',
+    ALTER COLUMN status SET NOT NULL,
+    ALTER COLUMN confidence SET DEFAULT 'low',
+    ALTER COLUMN confidence SET NOT NULL,
+    ALTER COLUMN evidence SET NOT NULL,
+    ALTER COLUMN managed_by SET DEFAULT 'user',
+    ALTER COLUMN managed_by SET NOT NULL;
 
 DO $$
 BEGIN
@@ -92,6 +171,15 @@ BEGIN
                 AND NULLIF(BTRIM(industry), '') IS NOT NULL
             ) NOT VALID;
     END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'ticker_matches_managed_by_allowed'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT ticker_matches_managed_by_allowed
+            CHECK (managed_by IN ('migration_seed', 'user')) NOT VALID;
+    END IF;
 END $$;
 
 DROP POLICY IF EXISTS "Enable insert for authenticated users" ON public.tickers;
@@ -110,12 +198,24 @@ CREATE POLICY "Enable read access for authenticated users" ON public.ticker_matc
 
 CREATE POLICY "Enable insert for authenticated users" ON public.ticker_matches
     FOR INSERT TO authenticated
-    WITH CHECK (auth.role() = 'authenticated' AND status <> 'confirmed');
+    WITH CHECK (
+        auth.role() = 'authenticated'
+        AND status <> 'confirmed'
+        AND managed_by = 'user'
+    );
 
 CREATE POLICY "Enable update for authenticated users" ON public.ticker_matches
     FOR UPDATE TO authenticated
-    USING (auth.role() = 'authenticated' AND status <> 'confirmed')
-    WITH CHECK (auth.role() = 'authenticated' AND status <> 'confirmed');
+    USING (
+        auth.role() = 'authenticated'
+        AND status <> 'confirmed'
+        AND managed_by = 'user'
+    )
+    WITH CHECK (
+        auth.role() = 'authenticated'
+        AND status <> 'confirmed'
+        AND managed_by = 'user'
+    );
 
 CREATE INDEX IF NOT EXISTS idx_ticker_matches_status
     ON public.ticker_matches(status);
@@ -152,7 +252,21 @@ VALUES
     ('SPHD', 'Invesco S&P 500 High Dividend Low Volatility ETF', 'NYSE ARCA', 'ETF', 'High Dividend Low Volatility')
 ON CONFLICT (ticker) DO NOTHING;
 
-INSERT INTO public.ticker_matches (
+DROP TABLE IF EXISTS pg_temp.ticker_matching_verified_seed;
+
+CREATE TEMP TABLE ticker_matching_verified_seed (
+    source_input TEXT PRIMARY KEY,
+    matched_ticker TEXT,
+    matched_company_name TEXT,
+    market TEXT,
+    sector TEXT,
+    industry TEXT,
+    status TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    evidence TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO pg_temp.ticker_matching_verified_seed (
     source_input,
     matched_ticker,
     matched_company_name,
@@ -200,5 +314,57 @@ VALUES
     ('SPDR', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'SPDR is an issuer or brand label rather than a unique security ticker.'),
     ('JP MORGAN', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'JP MORGAN is an issuer or brand label and does not uniquely identify a security.'),
     ('CREDIT SWISS', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'CREDIT SWISS is an issuer or legacy brand label and does not uniquely identify a security.'),
-    ('ATVI', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'ATVI is a historical ticker and the source name is abbreviated; do not link acquired or delisted history without statement-date confirmation.')
-ON CONFLICT (source_input) DO NOTHING;
+    ('ATVI', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'ATVI is a historical ticker and the source name is abbreviated; do not link acquired or delisted history without statement-date confirmation.');
+
+-- Adopt only an unchanged row from the pre-provenance migration. This changes
+-- ownership metadata, not user data, and lets the guarded upsert converge it.
+UPDATE public.ticker_matches AS existing
+SET managed_by = 'migration_seed',
+    updated_at = NOW()
+FROM pg_temp.ticker_matching_verified_seed AS seed
+WHERE existing.managed_by = 'user'
+  AND existing.source_input = seed.source_input
+  AND existing.matched_ticker IS NOT DISTINCT FROM seed.matched_ticker
+  AND existing.matched_company_name IS NOT DISTINCT FROM seed.matched_company_name
+  AND existing.market IS NOT DISTINCT FROM seed.market
+  AND existing.sector IS NOT DISTINCT FROM seed.sector
+  AND existing.industry IS NOT DISTINCT FROM seed.industry
+  AND existing.status IS NOT DISTINCT FROM seed.status
+  AND existing.confidence IS NOT DISTINCT FROM seed.confidence
+  AND existing.evidence IS NOT DISTINCT FROM seed.evidence;
+
+INSERT INTO public.ticker_matches (
+    source_input,
+    matched_ticker,
+    matched_company_name,
+    market,
+    sector,
+    industry,
+    status,
+    confidence,
+    evidence,
+    managed_by
+)
+SELECT seed.source_input,
+    seed.matched_ticker,
+    seed.matched_company_name,
+    seed.market,
+    seed.sector,
+    seed.industry,
+    seed.status,
+    seed.confidence,
+    seed.evidence,
+    'migration_seed'
+FROM pg_temp.ticker_matching_verified_seed AS seed
+ON CONFLICT (source_input) DO UPDATE
+SET matched_ticker = EXCLUDED.matched_ticker,
+    matched_company_name = EXCLUDED.matched_company_name,
+    market = EXCLUDED.market,
+    sector = EXCLUDED.sector,
+    industry = EXCLUDED.industry,
+    status = EXCLUDED.status,
+    confidence = EXCLUDED.confidence,
+    evidence = EXCLUDED.evidence,
+    managed_by = EXCLUDED.managed_by,
+    updated_at = NOW()
+WHERE public.ticker_matches.managed_by = 'migration_seed';

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -76,6 +76,8 @@ END $$;
 
 DROP POLICY IF EXISTS "Enable insert for authenticated users" ON public.tickers;
 DROP POLICY IF EXISTS "Enable update for authenticated users" ON public.tickers;
+DROP POLICY IF EXISTS "tickers_insert_authenticated" ON public.tickers;
+DROP POLICY IF EXISTS "tickers_update_authenticated" ON public.tickers;
 
 ALTER TABLE public.ticker_matches ENABLE ROW LEVEL SECURITY;
 

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -264,7 +264,7 @@ CREATE TEMP TABLE ticker_matching_verified_seed (
     status TEXT NOT NULL,
     confidence TEXT NOT NULL,
     evidence TEXT NOT NULL
-) ON COMMIT DROP;
+);
 
 INSERT INTO pg_temp.ticker_matching_verified_seed (
     source_input,
@@ -368,3 +368,5 @@ SET matched_ticker = EXCLUDED.matched_ticker,
     managed_by = EXCLUDED.managed_by,
     updated_at = NOW()
 WHERE public.ticker_matches.managed_by = 'migration_seed';
+
+DROP TABLE pg_temp.ticker_matching_verified_seed;

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -39,7 +39,7 @@ BEGIN
     ) THEN
         ALTER TABLE public.ticker_matches
             ADD CONSTRAINT ticker_matches_status_allowed
-            CHECK (status IN ('confirmed', 'manual_review', 'unmatched'));
+            CHECK (status IN ('confirmed', 'manual_review', 'unmatched')) NOT VALID;
     END IF;
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
@@ -48,7 +48,7 @@ BEGIN
     ) THEN
         ALTER TABLE public.ticker_matches
             ADD CONSTRAINT ticker_matches_confidence_allowed
-            CHECK (confidence IN ('high', 'medium', 'low'));
+            CHECK (confidence IN ('high', 'medium', 'low')) NOT VALID;
     END IF;
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
@@ -57,7 +57,7 @@ BEGIN
     ) THEN
         ALTER TABLE public.ticker_matches
             ADD CONSTRAINT confirmed_match_requires_ticker
-            CHECK (status <> 'confirmed' OR NULLIF(BTRIM(matched_ticker), '') IS NOT NULL);
+            CHECK (status <> 'confirmed' OR NULLIF(BTRIM(matched_ticker), '') IS NOT NULL) NOT VALID;
     END IF;
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
@@ -66,7 +66,7 @@ BEGIN
     ) THEN
         ALTER TABLE public.ticker_matches
             ADD CONSTRAINT confirmed_match_requires_high_confidence
-            CHECK (status <> 'confirmed' OR confidence = 'high');
+            CHECK (status <> 'confirmed' OR confidence = 'high') NOT VALID;
     END IF;
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
@@ -75,7 +75,7 @@ BEGIN
     ) THEN
         ALTER TABLE public.ticker_matches
             ADD CONSTRAINT match_evidence_requires_value
-            CHECK (NULLIF(BTRIM(evidence), '') IS NOT NULL);
+            CHECK (NULLIF(BTRIM(evidence), '') IS NOT NULL) NOT VALID;
     END IF;
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
@@ -90,7 +90,7 @@ BEGIN
                 AND NULLIF(BTRIM(market), '') IS NOT NULL
                 AND NULLIF(BTRIM(sector), '') IS NOT NULL
                 AND NULLIF(BTRIM(industry), '') IS NOT NULL
-            );
+            ) NOT VALID;
     END IF;
 END $$;
 

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -25,8 +25,54 @@ CREATE TABLE IF NOT EXISTS public.ticker_matches (
             AND NULLIF(BTRIM(market), '') IS NOT NULL
             AND NULLIF(BTRIM(sector), '') IS NOT NULL
             AND NULLIF(BTRIM(industry), '') IS NOT NULL
-        )
+    )
 );
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'confirmed_match_requires_ticker'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT confirmed_match_requires_ticker
+            CHECK (status <> 'confirmed' OR NULLIF(BTRIM(matched_ticker), '') IS NOT NULL);
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'confirmed_match_requires_high_confidence'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT confirmed_match_requires_high_confidence
+            CHECK (status <> 'confirmed' OR confidence = 'high');
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'match_evidence_requires_value'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT match_evidence_requires_value
+            CHECK (NULLIF(BTRIM(evidence), '') IS NOT NULL);
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'confirmed_match_requires_details'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT confirmed_match_requires_details
+            CHECK (
+                status <> 'confirmed'
+                OR NULLIF(BTRIM(matched_company_name), '') IS NOT NULL
+                AND NULLIF(BTRIM(market), '') IS NOT NULL
+                AND NULLIF(BTRIM(sector), '') IS NOT NULL
+                AND NULLIF(BTRIM(industry), '') IS NOT NULL
+            );
+    END IF;
+END $$;
 
 ALTER TABLE public.ticker_matches ENABLE ROW LEVEL SECURITY;
 

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -1,0 +1,121 @@
+CREATE TABLE IF NOT EXISTS public.ticker_matches (
+    source_input TEXT PRIMARY KEY,
+    matched_ticker TEXT,
+    matched_company_name TEXT,
+    market TEXT,
+    sector TEXT,
+    industry TEXT,
+    status TEXT NOT NULL DEFAULT 'manual_review'
+        CHECK (status IN ('confirmed', 'manual_review', 'unmatched')),
+    confidence TEXT NOT NULL DEFAULT 'low'
+        CHECK (confidence IN ('high', 'medium', 'low')),
+    evidence TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT confirmed_match_requires_ticker
+        CHECK (status <> 'confirmed' OR NULLIF(BTRIM(matched_ticker), '') IS NOT NULL),
+    CONSTRAINT confirmed_match_requires_high_confidence
+        CHECK (status <> 'confirmed' OR confidence = 'high')
+);
+
+ALTER TABLE public.ticker_matches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Enable read access for authenticated users" ON public.ticker_matches;
+DROP POLICY IF EXISTS "Enable insert for authenticated users" ON public.ticker_matches;
+DROP POLICY IF EXISTS "Enable update for authenticated users" ON public.ticker_matches;
+
+CREATE POLICY "Enable read access for authenticated users" ON public.ticker_matches
+    FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY "Enable insert for authenticated users" ON public.ticker_matches
+    FOR INSERT TO authenticated WITH CHECK (auth.role() = 'authenticated');
+
+CREATE POLICY "Enable update for authenticated users" ON public.ticker_matches
+    FOR UPDATE TO authenticated USING (auth.role() = 'authenticated')
+    WITH CHECK (auth.role() = 'authenticated');
+
+CREATE INDEX IF NOT EXISTS idx_ticker_matches_status
+    ON public.ticker_matches(status);
+
+CREATE INDEX IF NOT EXISTS idx_ticker_matches_matched_ticker
+    ON public.ticker_matches(matched_ticker);
+
+INSERT INTO public.tickers (ticker, company_name_kr, exchange, sector, industry)
+VALUES
+    ('458730', 'TIGER 미국배당다우존스', 'KRX', 'ETF', '미국 배당주'),
+    ('498400', 'KODEX 200타겟위클리커버드콜', 'KRX', 'ETF', '커버드콜'),
+    ('102970', 'KODEX 증권', 'KRX', 'ETF', '금융'),
+    ('367380', 'ACE 미국나스닥100', 'KRX', 'ETF', '미국 나스닥100'),
+    ('379800', 'KODEX 미국S&P500', 'KRX', 'ETF', '미국 대형주'),
+    ('379810', 'KODEX 미국나스닥100', 'KRX', 'ETF', '미국 나스닥100'),
+    ('446720', 'SOL 미국배당다우존스', 'KRX', 'ETF', '미국 배당주'),
+    ('161510', 'PLUS 고배당주', 'KRX', 'ETF', '배당주'),
+    ('0167B0', 'SOL 200타겟위클리커버드콜', 'KRX', 'ETF', '커버드콜'),
+    ('229200', 'KODEX 코스닥150', 'KRX', 'ETF', '코스닥'),
+    ('395160', 'KODEX AI반도체', 'KRX', 'ETF', '반도체'),
+    ('455850', 'SOL AI반도체소부장', 'KRX', 'ETF', '반도체'),
+    ('BITO', 'ProShares Bitcoin ETF', 'NYSE ARCA', 'ETF', '비트코인 선물'),
+    ('QQQM', 'Invesco Nasdaq 100 ETF', 'NASDAQ', 'ETF', '미국 나스닥100'),
+    ('SBUX', 'Starbucks Corporation', 'NASDAQ', 'Consumer Cyclical', 'Restaurants'),
+    ('AMT', 'American Tower Corporation', 'NYSE', 'Real Estate', 'REIT'),
+    ('QCOM', 'QUALCOMM Incorporated', 'NASDAQ', 'Technology', 'Semiconductors'),
+    ('MS', 'Morgan Stanley', 'NYSE', 'Financial Services', 'Capital Markets'),
+    ('PEP', 'PepsiCo, Inc.', 'NASDAQ', 'Consumer Defensive', 'Beverages'),
+    ('MSCI', 'MSCI Inc.', 'NYSE', 'Financial Services', 'Financial Data'),
+    ('SPG', 'Simon Property Group, Inc.', 'NYSE', 'Real Estate', 'REIT'),
+    ('NKE', 'NIKE, Inc.', 'NYSE', 'Consumer Cyclical', 'Footwear & Apparel'),
+    ('XOM', 'Exxon Mobil Corporation', 'NYSE', 'Energy', 'Oil & Gas Integrated'),
+    ('EL', 'The Estée Lauder Companies Inc.', 'NYSE', 'Consumer Defensive', 'Household & Personal Products'),
+    ('SPHD', 'Invesco S&P 500 High Dividend Low Volatility ETF', 'NYSE ARCA', 'ETF', 'High Dividend Low Volatility')
+ON CONFLICT (ticker) DO NOTHING;
+
+INSERT INTO public.ticker_matches (
+    source_input,
+    matched_ticker,
+    matched_company_name,
+    market,
+    sector,
+    industry,
+    status,
+    confidence,
+    evidence
+)
+VALUES
+    ('458730', '458730', 'TIGER 미국배당다우존스', 'KRX', 'ETF', '미국 배당주', 'confirmed', 'high', 'TIGER official product document: https://www.tigeretf.com/upload/etf/20250804095349009577.pdf'),
+    ('498400', '498400', 'KODEX 200타겟위클리커버드콜', 'KRX', 'ETF', '커버드콜', 'confirmed', 'high', 'Samsung KODEX official product page: https://www.samsungfund.com/etf/product/view.do?id=2ETFP4&isBanner=Y'),
+    ('102970', '102970', 'KODEX 증권', 'KRX', 'ETF', '금융', 'confirmed', 'high', 'Samsung KODEX official product list: https://m.samsungfund.com/upload/kodex/newsroom/20260325170636388.pdf'),
+    ('367380', '367380', 'ACE 미국나스닥100', 'KRX', 'ETF', '미국 나스닥100', 'confirmed', 'high', 'ACE official product page: https://www.aceetf.co.kr/fund/K55101DB1182'),
+    ('379800', '379800', 'KODEX 미국S&P500', 'KRX', 'ETF', '미국 대형주', 'confirmed', 'high', 'Samsung KODEX official search: https://m.samsungfund.com/etf/search.do?searchText=379800'),
+    ('379810', '379810', 'KODEX 미국나스닥100', 'KRX', 'ETF', '미국 나스닥100', 'confirmed', 'high', 'Samsung KODEX official search: https://m.samsungfund.com/etf/search.do?searchText=379810'),
+    ('446720', '446720', 'SOL 미국배당다우존스', 'KRX', 'ETF', '미국 배당주', 'confirmed', 'high', 'SOL official product page: https://www.soletf.com/ko/fund/etf/210942'),
+    ('161510', '161510', 'PLUS 고배당주', 'KRX', 'ETF', '배당주', 'confirmed', 'high', 'PLUS official search: https://www.plusetf.co.kr/main/search?k=161510'),
+    ('229200', '229200', 'KODEX 코스닥150', 'KRX', 'ETF', '코스닥', 'confirmed', 'high', 'Samsung KODEX official product list: https://m.samsungfund.com/upload/kodex/newsroom/20260325170636388.pdf'),
+    ('395160', '395160', 'KODEX AI반도체', 'KRX', 'ETF', '반도체', 'confirmed', 'high', 'Samsung KODEX official product list: https://m.samsungfund.com/upload/kodex/newsroom/20260325170636388.pdf'),
+    ('455850', '455850', 'SOL AI반도체소부장', 'KRX', 'ETF', '반도체', 'confirmed', 'high', 'SOL official product page: https://www.soletf.com/ko/fund/etf/210980'),
+    ('SOL 200타겟위클리커버드콜', '0167B0', 'SOL 200타겟위클리커버드콜', 'KRX', 'ETF', '커버드콜', 'confirmed', 'high', 'SOL official product page identifies code 0167B0: https://www.soletf.co.kr/ko/fund/etf/211107?tabIndex=1'),
+    ('BITO', 'BITO', 'ProShares Bitcoin ETF', 'NYSE ARCA', 'ETF', '비트코인 선물', 'confirmed', 'high', 'ProShares official product page: https://www.proshares.com/our-etfs/strategic/bito?source=GLOBAL_RISK_MANAGED'),
+    ('QQQM', 'QQQM', 'Invesco Nasdaq 100 ETF', 'NASDAQ', 'ETF', '미국 나스닥100', 'confirmed', 'high', 'Invesco official product information: https://www.invesco.com/us/en/solutions/innovation-suite.html'),
+    ('SBUX', 'SBUX', 'Starbucks Corporation', 'NASDAQ', 'Consumer Cyclical', 'Restaurants', 'confirmed', 'high', 'Starbucks investor FAQ identifies Nasdaq symbol SBUX: https://investor.starbucks.com/stock-info-and-resources/frequently-asked-questions-/default.aspx'),
+    ('AMT', 'AMT', 'American Tower Corporation', 'NYSE', 'Real Estate', 'REIT', 'confirmed', 'high', 'SEC filing identifies AMT on the New York Stock Exchange: https://www.sec.gov/Archives/edgar/data/1053507/000105350726000041/amt-20260305.htm'),
+    ('QCOM', 'QCOM', 'QUALCOMM Incorporated', 'NASDAQ', 'Technology', 'Semiconductors', 'confirmed', 'high', 'Qualcomm investor information identifies NASDAQ QCOM: https://investor.qualcomm.com/overview/default.aspx'),
+    ('MS', 'MS', 'Morgan Stanley', 'NYSE', 'Financial Services', 'Capital Markets', 'confirmed', 'high', 'Morgan Stanley investor relations identifies NYSE: MS: https://www.morganstanley.com/about-us-ir'),
+    ('PEP', 'PEP', 'PepsiCo, Inc.', 'NASDAQ', 'Consumer Defensive', 'Beverages', 'confirmed', 'high', 'PepsiCo investor release identifies NASDAQ PEP: https://www.pepsico.com/newsroom/press-releases/2026/pepsico-announces-webcast-of-annual-meeting-of-shareholders'),
+    ('MSCI', 'MSCI', 'MSCI Inc.', 'NYSE', 'Financial Services', 'Financial Data', 'confirmed', 'high', 'MSCI investor FAQ identifies ticker MSCI and NYSE: https://ir.msci.com/frequently-asked-questions'),
+    ('SPG', 'SPG', 'Simon Property Group, Inc.', 'NYSE', 'Real Estate', 'REIT', 'confirmed', 'high', 'Simon investor relations identifies NYSE: SPG: https://investors.simon.com/'),
+    ('NKE', 'NKE', 'NIKE, Inc.', 'NYSE', 'Consumer Cyclical', 'Footwear & Apparel', 'confirmed', 'high', 'NIKE investor release identifies NYSE:NKE: https://investors.nike.com/investors/news-events-and-reports/investor-news/investor-news-details/2026/NIKE-Inc--Reports-Fiscal-2026-Fourth-Quarter-and-Full-Year-Results/default.aspx'),
+    ('XOM', 'XOM', 'Exxon Mobil Corporation', 'NYSE', 'Energy', 'Oil & Gas Integrated', 'confirmed', 'high', 'ExxonMobil release identifies NYSE:XOM: https://corporate.exxonmobil.com/news/news-releases/2026/0310-redomiciling-the-company-from-new-jersey-to-texas'),
+    ('EL', 'EL', 'The Estée Lauder Companies Inc.', 'NYSE', 'Consumer Defensive', 'Household & Personal Products', 'confirmed', 'high', 'Estée Lauder investor FAQ identifies NYSE ticker EL: https://www.elcompanies.com/en/investors/investor-resources/faqs'),
+    ('SPHD', 'SPHD', 'Invesco S&P 500 High Dividend Low Volatility ETF', 'NYSE ARCA', 'ETF', 'High Dividend Low Volatility', 'confirmed', 'high', 'Invesco official fund details identify SPHD and NYSE ARCA: https://www.invesco.com/us/en/financial-products/etfs/invesco-sp-500-high-dividend-low-volatility-etf.html'),
+    ('486290', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'Ticker and entered name conflict: independent lookup identifies 486290 as TIGER 미국나스닥100타겟데일리커버드콜, while SOL official page identifies SOL 미국배당미국채혼합50 as 490490. Review the original statement: https://www.soletf.com/ko/fund/etf/211068?tabIndex=2'),
+    ('448880', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'Ticker and entered name conflict: 448880 is identified as ACE 24-12 회사채(AA-이상)액티브 in the available product report, not the entered KB RISE name. Review original statement: https://securities.miraeasset.com/bbs/download/2097498.pdf?attachmentId=2097498'),
+    ('RISE 삼성전자SK하이닉스채권혼합', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'Brand and product-code conflict: available product material identifies KODEX 삼성전자SK하이닉스채권혼합50 as 0177N0. Review original statement: https://www.samsungfund.com/upload/kodex/newsroom/20260630135348177.pdf'),
+    ('498410', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'Entered name conflicts with the official product name associated with code 498410, KODEX 금융고배당TOP10타겟위클리커버드콜. Review original statement: https://m.samsungfund.com/upload/kodex/newsroom/20260325170636388.pdf'),
+    ('133690', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'Ticker and abbreviated entered name need issuer-page confirmation before classification.'),
+    ('402970', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'Ticker has multiple similar ACE dividend product names in the source data; retain for issuer-page confirmation.'),
+    ('360750', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'Ticker and abbreviated TIGER name need issuer-page confirmation before classification.'),
+    ('364960', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'Ticker and TIGER BBIG name need issuer-page confirmation before classification.'),
+    ('SPDR', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'SPDR is an issuer or brand label rather than a unique security ticker.'),
+    ('JP MORGAN', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'JP MORGAN is an issuer or brand label and does not uniquely identify a security.'),
+    ('CREDIT SWISS', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'low', 'CREDIT SWISS is an issuer or legacy brand label and does not uniquely identify a security.'),
+    ('ATVI', NULL, NULL, NULL, NULL, NULL, 'manual_review', 'medium', 'ATVI is a historical ticker and the source name is abbreviated; do not link acquired or delisted history without statement-date confirmation.')
+ON CONFLICT (source_input) DO NOTHING;

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -74,6 +74,9 @@ BEGIN
     END IF;
 END $$;
 
+DROP POLICY IF EXISTS "Enable insert for authenticated users" ON public.tickers;
+DROP POLICY IF EXISTS "Enable update for authenticated users" ON public.tickers;
+
 ALTER TABLE public.ticker_matches ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS "Enable read access for authenticated users" ON public.ticker_matches;

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -6,8 +6,10 @@ CREATE TABLE IF NOT EXISTS public.ticker_matches (
     sector TEXT,
     industry TEXT,
     status TEXT NOT NULL DEFAULT 'manual_review'
+        CONSTRAINT ticker_matches_status_allowed
         CHECK (status IN ('confirmed', 'manual_review', 'unmatched')),
     confidence TEXT NOT NULL DEFAULT 'low'
+        CONSTRAINT ticker_matches_confidence_allowed
         CHECK (confidence IN ('high', 'medium', 'low')),
     evidence TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -30,6 +32,24 @@ CREATE TABLE IF NOT EXISTS public.ticker_matches (
 
 DO $$
 BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'ticker_matches_status_allowed'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT ticker_matches_status_allowed
+            CHECK (status IN ('confirmed', 'manual_review', 'unmatched'));
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conrelid = 'public.ticker_matches'::regclass
+          AND conname = 'ticker_matches_confidence_allowed'
+    ) THEN
+        ALTER TABLE public.ticker_matches
+            ADD CONSTRAINT ticker_matches_confidence_allowed
+            CHECK (confidence IN ('high', 'medium', 'low'));
+    END IF;
     IF NOT EXISTS (
         SELECT 1 FROM pg_constraint
         WHERE conrelid = 'public.ticker_matches'::regclass

--- a/database/ticker_matching.sql
+++ b/database/ticker_matching.sql
@@ -15,7 +15,17 @@ CREATE TABLE IF NOT EXISTS public.ticker_matches (
     CONSTRAINT confirmed_match_requires_ticker
         CHECK (status <> 'confirmed' OR NULLIF(BTRIM(matched_ticker), '') IS NOT NULL),
     CONSTRAINT confirmed_match_requires_high_confidence
-        CHECK (status <> 'confirmed' OR confidence = 'high')
+        CHECK (status <> 'confirmed' OR confidence = 'high'),
+    CONSTRAINT match_evidence_requires_value
+        CHECK (NULLIF(BTRIM(evidence), '') IS NOT NULL),
+    CONSTRAINT confirmed_match_requires_details
+        CHECK (
+            status <> 'confirmed'
+            OR NULLIF(BTRIM(matched_company_name), '') IS NOT NULL
+            AND NULLIF(BTRIM(market), '') IS NOT NULL
+            AND NULLIF(BTRIM(sector), '') IS NOT NULL
+            AND NULLIF(BTRIM(industry), '') IS NOT NULL
+        )
 );
 
 ALTER TABLE public.ticker_matches ENABLE ROW LEVEL SECURITY;
@@ -28,11 +38,13 @@ CREATE POLICY "Enable read access for authenticated users" ON public.ticker_matc
     FOR SELECT TO authenticated USING (true);
 
 CREATE POLICY "Enable insert for authenticated users" ON public.ticker_matches
-    FOR INSERT TO authenticated WITH CHECK (auth.role() = 'authenticated');
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.role() = 'authenticated' AND status <> 'confirmed');
 
 CREATE POLICY "Enable update for authenticated users" ON public.ticker_matches
-    FOR UPDATE TO authenticated USING (auth.role() = 'authenticated')
-    WITH CHECK (auth.role() = 'authenticated');
+    FOR UPDATE TO authenticated
+    USING (auth.role() = 'authenticated' AND status <> 'confirmed')
+    WITH CHECK (auth.role() = 'authenticated' AND status <> 'confirmed');
 
 CREATE INDEX IF NOT EXISTS idx_ticker_matches_status
     ON public.ticker_matches(status);

--- a/database/ticker_matching_static.test.js
+++ b/database/ticker_matching_static.test.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const sql = fs.readFileSync(path.join(__dirname, 'ticker_matching.sql'), 'utf8');
+const matchSeedBlock = sql.slice(sql.indexOf('CREATE TEMP TABLE ticker_matching_verified_seed'));
+
+test('ticker seed reruns update only migration-owned rows', () => {
+  assert.match(matchSeedBlock, /ON CONFLICT \(source_input\) DO UPDATE/);
+  assert.match(matchSeedBlock, /WHERE public\.ticker_matches\.managed_by = 'migration_seed'/);
+  assert.doesNotMatch(matchSeedBlock, /ON CONFLICT \(source_input\) DO NOTHING/);
+});
+
+test('authenticated users cannot mutate migration-owned rows', () => {
+  assert.match(
+    sql,
+    /CREATE POLICY "Enable update for authenticated users"[\s\S]*?USING \([\s\S]*?managed_by = 'user'[\s\S]*?\)[\s\S]*?WITH CHECK \([\s\S]*?managed_by = 'user'/,
+  );
+});
+
+test('legacy upgrades add the columns used by later migration statements', () => {
+  for (const column of ['matched_ticker', 'matched_company_name', 'market', 'sector', 'industry', 'status', 'confidence', 'evidence', 'managed_by']) {
+    assert.match(sql, new RegExp(`ADD COLUMN IF NOT EXISTS ${column} `));
+  }
+  assert.match(sql, /requires the existing source_input key column/);
+});

--- a/llm-wiki/wiki/architecture.md
+++ b/llm-wiki/wiki/architecture.md
@@ -40,7 +40,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 - `insertDividend`는 `supabase.auth.getUser()`로 현재 user를 다시 확인하고 row의 `user_id`를 설정한다.
 - Goal과 simulator 설정은 각 component가 user-scoped upsert를 수행한다.
 - Portfolio의 미등록 ticker는 authenticated 사용자가 `tickers`에 추가할 수 있다.
-- Portfolio의 미분류 입력값은 원본을 보존한 채 `ticker_matches`에서 근거·신뢰 수준·검토 상태를 기록한다. `confirmed` 상태만 canonical ticker로 분류·집계하고, 입력 폼의 종목 목록에도 반영한다.
+- Portfolio의 미분류 입력값은 원본을 보존한 채 `ticker_matches`에서 근거·신뢰 수준·검토 상태를 기록한다. 검증된 migration의 `confirmed` 상태만 canonical ticker로 분류·집계하고, 입력 폼의 종목 목록에도 반영한다. 화면에서 새로 입력한 후보는 `manual_review` 또는 `unmatched`로만 저장된다.
 
 ## External dependencies
 

--- a/llm-wiki/wiki/architecture.md
+++ b/llm-wiki/wiki/architecture.md
@@ -39,7 +39,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 - 배당 입력은 manual, OCR, text 화면에서 [`insertDividend.js`](../../src/api/insertDividend.js)로 수렴한다.
 - `insertDividend`는 `supabase.auth.getUser()`로 현재 user를 다시 확인하고 row의 `user_id`를 설정한다.
 - Goal과 simulator 설정은 각 component가 user-scoped upsert를 수행한다.
-- Portfolio의 미등록 ticker는 authenticated 사용자가 `tickers`에 추가할 수 있다.
+- `tickers`는 migration이 관리하는 검증된 read-only catalog로 읽는다.
 - Portfolio의 미분류 입력값은 원본을 보존한 채 `ticker_matches`에서 근거·신뢰 수준·검토 상태를 기록한다. 검증된 migration의 `confirmed` 상태만 canonical ticker로 분류·집계하고, 입력 폼의 종목 목록에도 반영한다. 화면에서 새로 입력한 후보는 `manual_review` 또는 `unmatched`로만 저장된다.
 
 ## External dependencies

--- a/llm-wiki/wiki/architecture.md
+++ b/llm-wiki/wiki/architecture.md
@@ -2,7 +2,7 @@
 title: Application Architecture
 type: architecture
 status: current
-updated: 2026-08-06
+updated: 2026-08-16
 source_refs: [S002]
 tags: [react, supabase, auth, data-flow]
 ---
@@ -29,7 +29,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 
 ## Read paths
 
-- [`useDividendData.js`](../../src/hooks/useDividendData.js): `dividend_entries`와 `tickers`를 조회하고 USD/KRW 환율을 결합한다.
+- [`useDividendData.js`](../../src/hooks/useDividendData.js): `dividend_entries`, `tickers`, `ticker_matches`를 조회하고 USD/KRW 환율을 결합한다.
 - [`DividendData.jsx`](../../src/components/DividendData.jsx): count를 포함한 server-side pagination query를 수행한다.
 - Dashboard, calendar, portfolio, notifications는 배당 데이터를 목적별로 재구성한다.
 - Goal과 simulator는 각각 `user_goals`, `simulation_settings`를 현재 user ID로 조회한다.
@@ -40,6 +40,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 - `insertDividend`는 `supabase.auth.getUser()`로 현재 user를 다시 확인하고 row의 `user_id`를 설정한다.
 - Goal과 simulator 설정은 각 component가 user-scoped upsert를 수행한다.
 - Portfolio의 미등록 ticker는 authenticated 사용자가 `tickers`에 추가할 수 있다.
+- Portfolio의 미분류 입력값은 원본을 보존한 채 `ticker_matches`에서 근거·신뢰 수준·검토 상태를 기록한다. `confirmed` 상태만 canonical ticker로 분류·집계하고, 입력 폼의 종목 목록에도 반영한다.
 
 ## External dependencies
 

--- a/llm-wiki/wiki/architecture.md
+++ b/llm-wiki/wiki/architecture.md
@@ -41,6 +41,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 - Goal과 simulator 설정은 각 component가 user-scoped upsert를 수행한다.
 - `tickers`는 migration이 관리하는 검증된 read-only catalog로 읽는다.
 - Portfolio의 미분류 입력값은 원본을 보존한 채 `ticker_matches`에서 근거·신뢰 수준·검토 상태를 기록한다. 검증된 migration의 `confirmed` 상태만 canonical ticker로 분류·집계하고, 입력 폼의 종목 목록에도 반영한다. 화면에서 새로 입력한 후보는 `manual_review` 또는 `unmatched`로만 저장된다.
+- 입력 매칭 map은 원본 alias를 공백·대소문자 기준으로 정규화하며, 같은 정규화 key가 여러 row에 나타나면 임의 row를 선택하지 않고 검색·alias 해석·집계 모두에서 보류한다.
 
 ## External dependencies
 

--- a/llm-wiki/wiki/architecture.md
+++ b/llm-wiki/wiki/architecture.md
@@ -41,7 +41,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 - Goal과 simulator 설정은 각 component가 user-scoped upsert를 수행한다.
 - `tickers`는 migration이 관리하는 검증된 read-only catalog로 읽는다.
 - Portfolio의 미분류 입력값은 원본을 보존한 채 `ticker_matches`에서 근거·신뢰 수준·검토 상태를 기록한다. 검증된 migration의 `confirmed` 상태만 canonical ticker로 분류·집계하고, 입력 폼의 종목 목록에도 반영한다. 화면에서 새로 입력한 후보는 `manual_review` 또는 `unmatched`로만 저장된다.
-- 입력 매칭 map은 원본 alias를 공백·대소문자 기준으로 정규화하며, 같은 정규화 key가 여러 row에 나타나면 임의 row를 선택하지 않고 검색·alias 해석·집계 모두에서 보류한다.
+- 입력 매칭 map은 원본·실제 종목명·티커 alias를 공백·대소문자 기준으로 정규화하며, 같은 key가 여러 row 또는 여러 canonical ticker에 나타나면 임의 row를 선택하지 않고 검색·alias 해석·집계 모두에서 보류한다.
 
 ## External dependencies
 

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -57,8 +57,10 @@ Migration 파일의 placeholder owner UUID는 실행 전에 실제 owner로 교�
 - [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql): 초기 `dividend_entries`와 AI provenance columns
 - [`sheet/ai_schema_update.sql`](../../sheet/ai_schema_update.sql): AI 관련 column과 index 추가
 - [`database/schema_update.sql`](../../database/schema_update.sql): ticker, goal, simulator schema와 seed
-- [`database/ticker_matching.sql`](../../database/ticker_matching.sql): 원본 입력 보존형 ticker 매칭과 RLS
-- [`database/security_hardening.sql`](../../database/security_hardening.sql): user ownership, composite key, RLS 강화
+- [`database/security_hardening.sql`](../../database/security_hardening.sql): 실제 owner UUID 치환 후 user ownership, composite key, RLS 강화
+- [`database/ticker_matching.sql`](../../database/ticker_matching.sql): security hardening 이후 실행하는 원본 입력 보존형 ticker 매칭, read-only catalog, RLS와 verified seed
+
+Fresh setup order is `schema_update.sql` → owner UUID를 채운 `security_hardening.sql` → `ticker_matching.sql`. `security_hardening.sql`의 placeholder owner UUID는 실행 전에 교체해야 한다.
 
 ## Related
 

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -48,7 +48,7 @@ tags: [supabase, postgres, rls, migrations]
 - `dividend_entries`, `user_goals`, `simulation_settings`에 non-null `user_id` 적용
 - 기존 row를 지정한 owner UUID로 backfill
 - select/insert/update/delete를 `auth.uid()`와 일치하는 row로 제한
-- `tickers`는 authenticated 사용자에게 read/insert/update 허용
+- `tickers`는 authenticated 사용자에게 read-only 허용
 
 Migration 파일의 placeholder owner UUID는 실행 전에 실제 owner로 교체해야 하며, repository의 파일 내용만으로 live 적용 여부를 추론하지 않는다.
 

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -37,6 +37,8 @@ tags: [supabase, postgres, rls, migrations]
 
 매칭 row에는 `matched_company_name`, `market`, `sector`, `industry`, `evidence`, `confidence`를 함께 기록한다. 매칭 저장은 기존 `dividend_entries` row를 수정하지 않는다.
 
+`confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
+
 [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql)의 초기 schema는 `stock` 중심이고, 현재 application은 `ticker`와 `company_name`을 사용한다. 이 차이는 migration을 순서 없는 단일 source of truth로 사용할 수 없다는 신호다.
 
 ## RLS model

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -37,11 +37,11 @@ tags: [supabase, postgres, rls, migrations]
 
 매칭 row에는 `matched_company_name`, `market`, `sector`, `industry`, `evidence`, `confidence`를 함께 기록한다. 매칭 저장은 기존 `dividend_entries` row를 수정하지 않는다.
 
-`confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. `tickers`도 authenticated client에는 read-only다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
+`confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태와 `managed_by = 'user'`만 허용한다. `managed_by = 'migration_seed'`인 seed row만 같은 migration을 다시 실행할 때 최신 verified 값으로 수렴한다. pre-provenance legacy row는 전체 seed payload가 변경 없이 일치할 때만 ownership metadata를 seed로 채택하고, 그 외에는 user로 보호한다. `tickers`도 authenticated client에는 read-only다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
 
 애플리케이션은 `source_input`, 실제 종목명, 티커 alias를 공백·대소문자 기준으로 정규화해 조회한다. 정규화 후 여러 match row 또는 여러 canonical ticker가 같은 key를 차지하면 어느 row도 검색 선택지나 canonical 해석에 사용하지 않고 수동 확인 대상으로 남긴다.
 
-기존 table에 이미 불완전한 legacy match가 있으면 upgrade migration은 `NOT VALID` check로 새 write를 먼저 차단하고, resolver도 필수 근거가 없는 row를 `Unknown`으로 보류한다. legacy row를 실제 종목으로 추정해 자동 보정하지 않는다.
+기존 table에 이미 불완전한 legacy match가 있으면 upgrade migration은 필요한 column을 `ADD COLUMN IF NOT EXISTS`로 보강하고 `NOT VALID` check로 새 write를 먼저 차단한다. 근거가 없는 기존 `confirmed` row는 `manual_review`로 낮춰 `Unknown`으로 보류하며, pre-provenance row는 전체 payload가 일치하는 경우에만 data 변경 없이 seed ownership을 채택한다.
 
 [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql)의 초기 schema는 `stock` 중심이고, 현재 application은 `ticker`와 `company_name`을 사용한다. 이 차이는 migration을 순서 없는 단일 source of truth로 사용할 수 없다는 신호다.
 

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -39,6 +39,8 @@ tags: [supabase, postgres, rls, migrations]
 
 `confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. `tickers`도 authenticated client에는 read-only다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
 
+기존 table에 이미 불완전한 legacy match가 있으면 upgrade migration은 `NOT VALID` check로 새 write를 먼저 차단하고, resolver도 필수 근거가 없는 row를 `Unknown`으로 보류한다. legacy row를 실제 종목으로 추정해 자동 보정하지 않는다.
+
 [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql)의 초기 schema는 `stock` 중심이고, 현재 application은 `ticker`와 `company_name`을 사용한다. 이 차이는 migration을 순서 없는 단일 source of truth로 사용할 수 없다는 신호다.
 
 ## RLS model

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -39,6 +39,8 @@ tags: [supabase, postgres, rls, migrations]
 
 `confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. `tickers`도 authenticated client에는 read-only다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
 
+애플리케이션은 `source_input` alias를 공백·대소문자 기준으로 정규화해 조회한다. 정규화 후 여러 match row가 같은 key를 차지하면 어느 row도 검색 선택지나 canonical 해석에 사용하지 않고 수동 확인 대상으로 남긴다.
+
 기존 table에 이미 불완전한 legacy match가 있으면 upgrade migration은 `NOT VALID` check로 새 write를 먼저 차단하고, resolver도 필수 근거가 없는 row를 `Unknown`으로 보류한다. legacy row를 실제 종목으로 추정해 자동 보정하지 않는다.
 
 [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql)의 초기 schema는 `stock` 중심이고, 현재 application은 `ticker`와 `company_name`을 사용한다. 이 차이는 migration을 순서 없는 단일 source of truth로 사용할 수 없다는 신호다.

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -2,7 +2,7 @@
 title: Data Model and RLS
 type: data-model
 status: current
-updated: 2026-08-06
+updated: 2026-08-16
 source_refs: [S002]
 tags: [supabase, postgres, rls, migrations]
 ---
@@ -17,6 +17,7 @@ tags: [supabase, postgres, rls, migrations]
 |---|---|---|
 | `dividend_entries` | 계좌, 종목, 금액, 지급일, 통화, 입력 방식과 confidence 저장 | `user_id = auth.uid()` |
 | `tickers` | ticker별 sector, industry, exchange, 한글명 metadata | authenticated 사용자 공유 |
+| `ticker_matches` | 원본 입력값과 실제 종목 후보, 시장, 근거, 신뢰 수준, 검토 상태 저장 | authenticated 사용자 공유 |
 | `user_goals` | 사용자별 `monthly_dividend_goal` 등 key/value 목표 | composite key `(user_id, key)` |
 | `simulation_settings` | 월 적립, yield, growth, reinvest 설정 | composite key `(user_id, id)` |
 
@@ -29,6 +30,12 @@ tags: [supabase, postgres, rls, migrations]
 - instrument: `ticker`, `company_name`
 - payment: `dividend_amount`, `payment_date`, `currency`
 - provenance: `input_method`, `confidence_score`
+
+## Instrument matching
+
+`public.ticker_matches.source_input`은 배당 원본의 입력값을 대문자 정규화해 저장하는 식별자다. `confirmed` 상태만 `matched_ticker`와 `tickers` metadata를 통해 포트폴리오 분류와 배당 집계의 canonical ticker로 해석한다. `manual_review`와 `unmatched`는 원본 입력값과 금액을 유지한 채 `Unknown`으로 남긴다.
+
+매칭 row에는 `matched_company_name`, `market`, `sector`, `industry`, `evidence`, `confidence`를 함께 기록한다. 매칭 저장은 기존 `dividend_entries` row를 수정하지 않는다.
 
 [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql)의 초기 schema는 `stock` 중심이고, 현재 application은 `ticker`와 `company_name`을 사용한다. 이 차이는 migration을 순서 없는 단일 source of truth로 사용할 수 없다는 신호다.
 
@@ -48,6 +55,7 @@ Migration 파일의 placeholder owner UUID는 실행 전에 실제 owner로 교�
 - [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql): 초기 `dividend_entries`와 AI provenance columns
 - [`sheet/ai_schema_update.sql`](../../sheet/ai_schema_update.sql): AI 관련 column과 index 추가
 - [`database/schema_update.sql`](../../database/schema_update.sql): ticker, goal, simulator schema와 seed
+- [`database/ticker_matching.sql`](../../database/ticker_matching.sql): 원본 입력 보존형 ticker 매칭과 RLS
 - [`database/security_hardening.sql`](../../database/security_hardening.sql): user ownership, composite key, RLS 강화
 
 ## Related

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -16,7 +16,7 @@ tags: [supabase, postgres, rls, migrations]
 | Table | Responsibility | Ownership |
 |---|---|---|
 | `dividend_entries` | 계좌, 종목, 금액, 지급일, 통화, 입력 방식과 confidence 저장 | `user_id = auth.uid()` |
-| `tickers` | ticker별 sector, industry, exchange, 한글명 metadata | authenticated 사용자 공유 |
+| `tickers` | 검증된 ticker별 sector, industry, exchange, 한글명 metadata | authenticated read-only catalog |
 | `ticker_matches` | 원본 입력값과 실제 종목 후보, 시장, 근거, 신뢰 수준, 검토 상태 저장 | authenticated 사용자 공유 |
 | `user_goals` | 사용자별 `monthly_dividend_goal` 등 key/value 목표 | composite key `(user_id, key)` |
 | `simulation_settings` | 월 적립, yield, growth, reinvest 설정 | composite key `(user_id, id)` |
@@ -37,7 +37,7 @@ tags: [supabase, postgres, rls, migrations]
 
 매칭 row에는 `matched_company_name`, `market`, `sector`, `industry`, `evidence`, `confidence`를 함께 기록한다. 매칭 저장은 기존 `dividend_entries` row를 수정하지 않는다.
 
-`confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
+`confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. `tickers`도 authenticated client에는 read-only다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
 
 [`sheet/supabase_setup.sql`](../../sheet/supabase_setup.sql)의 초기 schema는 `stock` 중심이고, 현재 application은 `ticker`와 `company_name`을 사용한다. 이 차이는 migration을 순서 없는 단일 source of truth로 사용할 수 없다는 신호다.
 

--- a/llm-wiki/wiki/data-model.md
+++ b/llm-wiki/wiki/data-model.md
@@ -39,7 +39,7 @@ tags: [supabase, postgres, rls, migrations]
 
 `confirmed` row는 migration의 검증된 seed로만 생성되며, authenticated client의 RLS insert/update는 `manual_review`·`unmatched` 상태만 허용한다. `tickers`도 authenticated client에는 read-only다. 따라서 화면에서 입력한 후보 정보는 기록되지만 확정 전에는 분류·집계에 사용되지 않는다.
 
-애플리케이션은 `source_input` alias를 공백·대소문자 기준으로 정규화해 조회한다. 정규화 후 여러 match row가 같은 key를 차지하면 어느 row도 검색 선택지나 canonical 해석에 사용하지 않고 수동 확인 대상으로 남긴다.
+애플리케이션은 `source_input`, 실제 종목명, 티커 alias를 공백·대소문자 기준으로 정규화해 조회한다. 정규화 후 여러 match row 또는 여러 canonical ticker가 같은 key를 차지하면 어느 row도 검색 선택지나 canonical 해석에 사용하지 않고 수동 확인 대상으로 남긴다.
 
 기존 table에 이미 불완전한 legacy match가 있으면 upgrade migration은 `NOT VALID` check로 새 write를 먼저 차단하고, resolver도 필수 근거가 없는 row를 `Unknown`으로 보류한다. legacy row를 실제 종목으로 추정해 자동 보정하지 않는다.
 

--- a/llm-wiki/wiki/known-gaps.md
+++ b/llm-wiki/wiki/known-gaps.md
@@ -2,7 +2,7 @@
 title: Known Gaps and Open Risks
 type: risk
 status: current
-updated: 2026-08-06
+updated: 2026-08-16
 source_refs: [S002, S003]
 tags: [risk, drift, follow-up]
 ---

--- a/llm-wiki/wiki/known-gaps.md
+++ b/llm-wiki/wiki/known-gaps.md
@@ -55,6 +55,7 @@ tags: [risk, drift, follow-up]
 - [Data model](./data-model.md)
 - [Deployment and security](./deployment-and-security.md)
 - [Architecture](./architecture.md)
+- [Contribution and PR policy](./contribution-and-pr-policy.md)
 
 ## Sources
 

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -54,6 +54,11 @@
 
 - `schema_update.sql`과 `security_hardening.sql`에서도 ticker insert/update policy를 재생성하지 않도록 정렬해 migration 실행 순서에 따른 쓰기 재개를 막았다.
 
+## [2026-08-16] fix | 입력 목록의 확정 항목 경계
+
+- 수동 검토·최근 입력값이 종목 선택 목록에 다시 노출되지 않도록 `DividendForm`의 목록을 `confirmed` match의 원본·실제 종목명·티커 alias로 제한했다.
+- 새 미확인 값은 기존 custom 입력으로 계속 기록하고, 확정 전 분류·집계에는 사용하지 않는다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -39,6 +39,12 @@
 - authenticated client는 `manual_review`·`unmatched`만 저장할 수 있고, `confirmed`는 검증된 migration seed와 완전한 근거·분류 필드를 요구하도록 했다.
 - 기존 `dividend_entries`는 계속 수정하지 않는다.
 
+## [2026-08-16] fix | 확정 alias와 수동 입력 집계 충돌 방지
+
+- 확정 canonical ticker와 동일한 원본 문자열을 가진 미확정 row가 하나의 aggregate로 합쳐지지 않도록 집계 key를 검증 상태와 원본 기준으로 분리했다.
+- 입력 폼에서 확정 종목명·티커 alias를 선택해도 유일한 확정 match로만 해석하도록 했고, 확정 match의 evidence metadata가 mutable `tickers` metadata보다 우선하도록 했다.
+- 기존 테이블에도 제약이 추가되도록 migration을 idempotent하게 보강했다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -56,3 +56,16 @@
 - 대시보드의 월 평균 배당금은 올해 1월부터 현재 월까지의 배당 합계를 경과 월 수로 나눈다.
 - 작년 같은 기간의 월평균과 전년 동기 증감률을 함께 표시하고, 비교 가능한 작년 데이터가 없으면 비교 행을 숨긴다.
 - 근거: [`DividendChart.jsx`](../../src/components/DividendChart.jsx), [`dividendKpi.js`](../../src/utils/dividendKpi.js)
+
+## [2026-08-16] update | 원본 보존형 종목 매칭 검토 흐름
+
+- `ticker_matches`에 원본 입력값, 실제 종목명·티커·시장·분류, 근거, 신뢰 수준, 검토 상태를 기록하도록 했다.
+- `confirmed`만 포트폴리오 분류·배당 집계와 종목 입력 목록에 반영하고 `manual_review`·`unmatched`는 Unknown으로 보류한다.
+- 기존 `dividend_entries`는 수정하지 않는다.
+- 근거: [`database/ticker_matching.sql`](../../database/ticker_matching.sql), [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`PortfolioAnalysis.jsx`](../../src/components/PortfolioAnalysis.jsx)
+
+## [2026-08-16] lint | 원본 보존형 종목 매칭 Wiki 무결성
+
+- 9개 Wiki 페이지의 index 등록, inbound link, 상대 링크, frontmatter, `Sources`, `Related`, source reference를 검사했다.
+- 매칭 근거에 실제 계좌번호·개인정보·secret이 포함되지 않았음을 확인했다.
+- Result: pass.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -121,6 +121,6 @@
 
 ## [2026-08-16] security | 정규화 alias 충돌 보류
 
-- 공백·대소문자 정규화 후 같은 원본 alias를 가진 match row가 여러 개면 임의 row가 덮어써지지 않도록 map을 보류 값으로 만들었다.
-- 검색 선택지와 포트폴리오 alias resolver가 같은 fail-closed map을 사용해 충돌 입력을 수동 확인 대상으로 남긴다.
+- 공백·대소문자 정규화 후 같은 원본 alias를 가진 match row가 여러 개이거나 실제 종목명·티커 alias가 여러 canonical ticker를 가리키면 임의 row가 선택되지 않도록 보류한다.
+- 검색 선택지와 포트폴리오 alias resolver가 같은 canonical alias 집합을 사용해 충돌 입력을 수동 확인 대상으로 남긴다.
 - 근거: [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`src/components/DividendForm.jsx`](../../src/components/DividendForm.jsx), [`src/components/DividendForm.test.jsx`](../../src/components/DividendForm.test.jsx)

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -59,6 +59,10 @@
 - 수동 검토·최근 입력값이 종목 선택 목록에 다시 노출되지 않도록 `DividendForm`의 목록을 `confirmed` match의 원본·실제 종목명·티커 alias로 제한했다.
 - 새 미확인 값은 기존 custom 입력으로 계속 기록하고, 확정 전 분류·집계에는 사용하지 않는다.
 
+## [2026-08-16] docs | matching migration 실행 순서
+
+- README와 data-model Wiki에 `schema_update.sql` → owner UUID를 채운 `security_hardening.sql` → `ticker_matching.sql` 순서와 placeholder owner 실행 금지 조건을 명시했다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -124,3 +124,14 @@
 - 공백·대소문자 정규화 후 같은 원본 alias를 가진 match row가 여러 개이거나 실제 종목명·티커 alias가 여러 canonical ticker를 가리키면 임의 row가 선택되지 않도록 보류한다.
 - 검색 선택지와 포트폴리오 alias resolver가 같은 canonical alias 집합을 사용해 충돌 입력을 수동 확인 대상으로 남긴다.
 - 근거: [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`src/components/DividendForm.jsx`](../../src/components/DividendForm.jsx), [`src/components/DividendForm.test.jsx`](../../src/components/DividendForm.test.jsx)
+
+## [2026-08-16] fix | ticker matching seed upgrade 수렴 정책
+
+- `ticker_matching.sql`에 기존 `ticker_matches` table의 누락 column을 보강하는 idempotent upgrade path와 `source_input` key fail-fast check를 추가했다.
+- `managed_by`로 migration seed와 사용자 row를 구분하고, seed 소유 row만 verified 값으로 갱신한다. pre-provenance row는 전체 seed payload가 일치할 때만 data 변경 없이 seed ownership을 채택하고, 그 외 ownership을 알 수 없는 legacy row는 user-owned로 보호해 manual review data를 덮어쓰지 않는다.
+- 근거: [`database/ticker_matching.sql`](../../database/ticker_matching.sql), [`wiki/data-model.md`](./data-model.md)
+
+## [2026-08-16] lint | ticker matching seed upgrade 문서 무결성
+
+- Wiki index coverage, 상대 링크, frontmatter source reference를 다시 검사했다.
+- Result: pass.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -112,3 +112,9 @@
 - 9개 Wiki 페이지의 index 등록, inbound link, 상대 링크, frontmatter, `Sources`, `Related`, source reference를 검사했다.
 - 매칭 근거에 실제 계좌번호·개인정보·secret이 포함되지 않았음을 확인했다.
 - Result: pass.
+
+## [2026-08-16] fix | 불완전한 확정 alias 보류
+
+- legacy row가 `confirmed` 상태만 가지고 있더라도 실제 종목명·티커·시장·분류·근거와 high confidence가 모두 없으면 검색 목록과 alias resolver에서 제외한다.
+- 불완전한 기존 row는 migration의 `NOT VALID` upgrade 제약과 함께 Unknown 또는 수동 확인 대상으로 남긴다.
+- 근거: [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`src/components/DividendForm.jsx`](../../src/components/DividendForm.jsx)

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -63,6 +63,10 @@
 
 - README와 data-model Wiki에 `schema_update.sql` → owner UUID를 채운 `security_hardening.sql` → `ticker_matching.sql` 순서와 placeholder owner 실행 금지 조건을 명시했다.
 
+## [2026-08-16] security | matching allowed-value 제약 보강
+
+- 기존 `ticker_matches` table에도 status와 confidence allowed-value 제약이 추가되도록 upgrade-safe migration block을 보강했다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -67,6 +67,15 @@
 
 - 기존 `ticker_matches` table에도 status와 confidence allowed-value 제약이 추가되도록 upgrade-safe migration block을 보강했다.
 
+## [2026-08-16] security | legacy match 보류 경계
+
+- 기존 invalid match row 때문에 migration이 중단되지 않도록 upgrade 제약은 `NOT VALID`로 새 write를 차단한다.
+- resolver는 기존 row에도 high confidence, 실제 종목명·시장·분류·근거가 모두 있어야 confirmed로 취급하며, 불완전 row는 Unknown으로 보류한다.
+
+## [2026-08-16] lint | Wiki inbound link 보강
+
+- `known-gaps.md`에서 `contribution-and-pr-policy.md`를 연결해 index 등록뿐 아니라 다른 Wiki page의 inbound link도 만족하도록 했다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -45,6 +45,11 @@
 - 입력 폼에서 확정 종목명·티커 alias를 선택해도 유일한 확정 match로만 해석하도록 했고, 확정 match의 evidence metadata가 mutable `tickers` metadata보다 우선하도록 했다.
 - 기존 테이블에도 제약이 추가되도록 migration을 idempotent하게 보강했다.
 
+## [2026-08-16] security | ticker catalog 쓰기 경계
+
+- authenticated client가 mutable `tickers` metadata를 이용해 근거 없는 분류를 만들지 않도록 `ticker_matches` migration에서 ticker insert/update policy를 제거했다.
+- 기존 catalog read와 confirmed evidence 우선 resolver 동작은 유지하고, 새로운 후보는 `ticker_matches`의 수동 검토 상태로만 기록한다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -118,3 +118,9 @@
 - legacy row가 `confirmed` 상태만 가지고 있더라도 실제 종목명·티커·시장·분류·근거와 high confidence가 모두 없으면 검색 목록과 alias resolver에서 제외한다.
 - 불완전한 기존 row는 migration의 `NOT VALID` upgrade 제약과 함께 Unknown 또는 수동 확인 대상으로 남긴다.
 - 근거: [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`src/components/DividendForm.jsx`](../../src/components/DividendForm.jsx)
+
+## [2026-08-16] security | 정규화 alias 충돌 보류
+
+- 공백·대소문자 정규화 후 같은 원본 alias를 가진 match row가 여러 개면 임의 row가 덮어써지지 않도록 map을 보류 값으로 만들었다.
+- 검색 선택지와 포트폴리오 alias resolver가 같은 fail-closed map을 사용해 충돌 입력을 수동 확인 대상으로 남긴다.
+- 근거: [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`src/components/DividendForm.jsx`](../../src/components/DividendForm.jsx), [`src/components/DividendForm.test.jsx`](../../src/components/DividendForm.test.jsx)

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -50,6 +50,10 @@
 - authenticated client가 mutable `tickers` metadata를 이용해 근거 없는 분류를 만들지 않도록 `ticker_matches` migration에서 ticker insert/update policy를 제거했다.
 - 기존 catalog read와 confirmed evidence 우선 resolver 동작은 유지하고, 새로운 후보는 `ticker_matches`의 수동 검토 상태로만 기록한다.
 
+## [2026-08-16] security | ticker policy migration order alignment
+
+- `schema_update.sql`과 `security_hardening.sql`에서도 ticker insert/update policy를 재생성하지 않도록 정렬해 migration 실행 순서에 따른 쓰기 재개를 막았다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -33,6 +33,12 @@
 - 상대 링크, root policy parity, secret token과 JWT 패턴을 검사했다.
 - Result: pass.
 
+## [2026-08-16] update | 확정 매칭 쓰기 경계 강화
+
+- 수동 검토 입력이 기존 `tickers` metadata를 우연히 공유해도 `Unknown`을 벗어나지 않도록 집계 resolver를 수정했다.
+- authenticated client는 `manual_review`·`unmatched`만 저장할 수 있고, `confirmed`는 검증된 migration seed와 완전한 근거·분류 필드를 요구하도록 했다.
+- 기존 `dividend_entries`는 계속 수정하지 않는다.
+
 ## [2026-08-08] lint | Security policy remediation
 
 - 외부 raw source의 모든 지시문을 비신뢰 데이터로 취급하도록 ingest 신뢰 경계를 명시했다.

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -44,30 +44,17 @@ function DividendForm() {
         console.error('Supabase distinct 쿼리 에러:', error);
         return;
       }
-      // 최신순 정렬 후 중복 제거 (종목명)
-      const sortedCompanies = (data || [])
-        .filter(item => item.payment_date >= oneYearAgoStr)
-        .sort((a, b) => b.payment_date.localeCompare(a.payment_date));
-      const recentCompanies = [];
-      const seenCompanies = new Set();
-      for (const item of sortedCompanies) {
-        const name = item.company_name && item.company_name.trim();
-        if (name && !seenCompanies.has(name)) {
-          recentCompanies.push(name);
-          seenCompanies.add(name);
-        }
-      }
       const { data: matchData, error: matchError } = await supabase
         .from('ticker_matches')
         .select('source_input, matched_company_name, matched_ticker, status');
       if (matchError) {
-        setCompanyNames(recentCompanies);
+        setCompanyNames([]);
       } else {
         const confirmedMatches = (matchData || [])
           .filter((match) => match.status === 'confirmed')
           .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
           .filter(Boolean);
-        setCompanyNames([...new Set([...recentCompanies, ...confirmedMatches])]);
+        setCompanyNames([...new Set(confirmedMatches)]);
       }
       // 최신순 정렬 후 중복 제거 (계좌명)
       const sortedAccounts = (data || [])

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -1,7 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import insertDividend from '../api/insertDividend';
 import { supabase } from '../api/supabaseClient';
-import { isVerifiedMatch } from '../utils/tickerMatching';
+import { buildTickerMatchesMap, isVerifiedMatch } from '../utils/tickerMatching';
+
+export function getVerifiedMatchChoices(matchData) {
+  const matchMap = buildTickerMatchesMap(matchData);
+  return [...new Set(
+    Object.values(matchMap)
+      .filter(isVerifiedMatch)
+      .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
+      .filter(Boolean)
+  )];
+}
 
 function getToday() {
   const d = new Date();
@@ -51,11 +61,7 @@ function DividendForm() {
       if (matchError) {
         setCompanyNames([]);
       } else {
-        const confirmedMatches = (matchData || [])
-          .filter(isVerifiedMatch)
-          .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
-          .filter(Boolean);
-        setCompanyNames([...new Set(confirmedMatches)]);
+        setCompanyNames(getVerifiedMatchChoices(matchData));
       }
       // 최신순 정렬 후 중복 제거 (계좌명)
       const sortedAccounts = (data || [])

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -57,7 +57,18 @@ function DividendForm() {
           seenCompanies.add(name);
         }
       }
-      setCompanyNames(recentCompanies);
+      const { data: matchData, error: matchError } = await supabase
+        .from('ticker_matches')
+        .select('source_input, matched_company_name, matched_ticker, status');
+      if (matchError) {
+        setCompanyNames(recentCompanies);
+      } else {
+        const confirmedMatches = (matchData || [])
+          .filter((match) => match.status === 'confirmed')
+          .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
+          .filter(Boolean);
+        setCompanyNames([...new Set([...recentCompanies, ...confirmedMatches])]);
+      }
       // 최신순 정렬 후 중복 제거 (계좌명)
       const sortedAccounts = (data || [])
         .filter(item => item.payment_date >= oneYearAgoStr)

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -47,7 +47,7 @@ function DividendForm() {
       }
       const { data: matchData, error: matchError } = await supabase
         .from('ticker_matches')
-        .select('source_input, matched_company_name, matched_ticker, status');
+        .select('source_input, matched_company_name, matched_ticker, market, sector, industry, evidence, confidence, status');
       if (matchError) {
         setCompanyNames([]);
       } else {

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import insertDividend from '../api/insertDividend';
 import { supabase } from '../api/supabaseClient';
+import { isVerifiedMatch } from '../utils/tickerMatching';
 
 function getToday() {
   const d = new Date();
@@ -51,7 +52,7 @@ function DividendForm() {
         setCompanyNames([]);
       } else {
         const confirmedMatches = (matchData || [])
-          .filter((match) => match.status === 'confirmed')
+          .filter(isVerifiedMatch)
           .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
           .filter(Boolean);
         setCompanyNames([...new Set(confirmedMatches)]);

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -1,30 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import insertDividend from '../api/insertDividend';
 import { supabase } from '../api/supabaseClient';
-import { buildTickerMatchesMap, isVerifiedMatch, normalizeTickerInput } from '../utils/tickerMatching';
+import { buildTickerMatchesMap, getVerifiedMatchAliasKeys, isVerifiedMatch, normalizeTickerInput } from '../utils/tickerMatching';
 
 export function getVerifiedMatchChoices(matchData) {
   const matchMap = buildTickerMatchesMap(matchData);
   const verifiedMatches = Object.values(matchMap).filter(isVerifiedMatch);
-  const aliasTickers = new Map();
-
-  verifiedMatches.forEach((match) => {
-    const matchedTicker = normalizeTickerInput(match.matched_ticker);
-    [match.source_input, match.matched_company_name, match.matched_ticker].forEach((alias) => {
-      const aliasKey = normalizeTickerInput(alias);
-      if (!aliasKey) return;
-      const tickers = aliasTickers.get(aliasKey) || new Set();
-      tickers.add(matchedTicker);
-      aliasTickers.set(aliasKey, tickers);
-    });
-  });
+  const verifiedAliases = getVerifiedMatchAliasKeys(matchMap);
 
   return [...new Set(
     verifiedMatches
       .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
       .filter((alias) => {
         const aliasKey = normalizeTickerInput(alias);
-        return aliasKey && aliasTickers.get(aliasKey)?.size === 1;
+        return aliasKey && verifiedAliases.has(aliasKey);
       })
   )];
 }

--- a/src/components/DividendForm.jsx
+++ b/src/components/DividendForm.jsx
@@ -1,15 +1,31 @@
 import React, { useState, useEffect } from 'react';
 import insertDividend from '../api/insertDividend';
 import { supabase } from '../api/supabaseClient';
-import { buildTickerMatchesMap, isVerifiedMatch } from '../utils/tickerMatching';
+import { buildTickerMatchesMap, isVerifiedMatch, normalizeTickerInput } from '../utils/tickerMatching';
 
 export function getVerifiedMatchChoices(matchData) {
   const matchMap = buildTickerMatchesMap(matchData);
+  const verifiedMatches = Object.values(matchMap).filter(isVerifiedMatch);
+  const aliasTickers = new Map();
+
+  verifiedMatches.forEach((match) => {
+    const matchedTicker = normalizeTickerInput(match.matched_ticker);
+    [match.source_input, match.matched_company_name, match.matched_ticker].forEach((alias) => {
+      const aliasKey = normalizeTickerInput(alias);
+      if (!aliasKey) return;
+      const tickers = aliasTickers.get(aliasKey) || new Set();
+      tickers.add(matchedTicker);
+      aliasTickers.set(aliasKey, tickers);
+    });
+  });
+
   return [...new Set(
-    Object.values(matchMap)
-      .filter(isVerifiedMatch)
+    verifiedMatches
       .flatMap((match) => [match.source_input, match.matched_company_name, match.matched_ticker])
-      .filter(Boolean)
+      .filter((alias) => {
+        const aliasKey = normalizeTickerInput(alias);
+        return aliasKey && aliasTickers.get(aliasKey)?.size === 1;
+      })
   )];
 }
 

--- a/src/components/DividendForm.test.jsx
+++ b/src/components/DividendForm.test.jsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import DividendForm from './DividendForm';
+import DividendForm, { getVerifiedMatchChoices } from './DividendForm';
 import insertDividend from '../api/insertDividend';
 
 jest.mock('../api/insertDividend', () => jest.fn(() => Promise.resolve({ success: true })));
@@ -53,6 +53,35 @@ jest.mock('../api/supabaseClient', () => ({
     })
   }
 }));
+
+test('does not expose normalized-colliding aliases in the input choices', () => {
+  const choices = getVerifiedMatchChoices([
+    {
+      source_input: 'Source Name',
+      matched_company_name: 'Apple Inc.',
+      matched_ticker: 'AAPL',
+      market: 'NASDAQ',
+      sector: 'Technology',
+      industry: 'Consumer Electronics',
+      evidence: 'Issuer verified',
+      confidence: 'high',
+      status: 'confirmed'
+    },
+    {
+      source_input: ' source name ',
+      matched_company_name: 'Microsoft Corporation',
+      matched_ticker: 'MSFT',
+      market: 'NASDAQ',
+      sector: 'Technology',
+      industry: 'Software',
+      evidence: 'Issuer verified',
+      confidence: 'high',
+      status: 'confirmed'
+    }
+  ]);
+
+  expect(choices).toEqual([]);
+});
 
 test('keeps payment date set to today after submitting a dividend', async () => {
   jest.useFakeTimers();

--- a/src/components/DividendForm.test.jsx
+++ b/src/components/DividendForm.test.jsx
@@ -6,7 +6,7 @@ jest.mock('../api/insertDividend', () => jest.fn(() => Promise.resolve({ success
 
 jest.mock('../api/supabaseClient', () => ({
   supabase: {
-    from: () => ({
+    from: (table) => ({
       select: (columns) => {
         if (columns === '*') {
           return {
@@ -14,6 +14,25 @@ jest.mock('../api/supabaseClient', () => ({
               limit: () => Promise.resolve({ data: [], error: null })
             })
           };
+        }
+
+        if (table === 'ticker_matches') {
+          return Promise.resolve({
+            data: [
+              {
+                source_input: '삼성전자',
+                matched_company_name: '삼성전자',
+                matched_ticker: '005930',
+                market: 'KRX',
+                sector: 'Technology',
+                industry: 'Semiconductors',
+                evidence: 'test evidence',
+                confidence: 'high',
+                status: 'confirmed'
+              }
+            ],
+            error: null
+          });
         }
 
         return Promise.resolve({

--- a/src/components/DividendForm.test.jsx
+++ b/src/components/DividendForm.test.jsx
@@ -17,6 +17,10 @@ jest.mock('../api/supabaseClient', () => ({
         }
 
         if (table === 'ticker_matches') {
+          if (columns !== 'source_input, matched_company_name, matched_ticker, market, sector, industry, evidence, confidence, status') {
+            return Promise.resolve({ data: null, error: new Error('incomplete match projection') });
+          }
+
           return Promise.resolve({
             data: [
               {
@@ -59,6 +63,7 @@ test('keeps payment date set to today after submitting a dividend', async () => 
     render(<DividendForm />);
 
     fireEvent.change(await screen.findByLabelText(/계좌명/i), { target: { value: 'IRP' } });
+    expect(await screen.findByRole('option', { name: '삼성전자' })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText(/종목명/i), { target: { value: '삼성전자' } });
     fireEvent.change(screen.getByPlaceholderText('금액'), { target: { value: '12000' } });
 

--- a/src/components/DividendForm.test.jsx
+++ b/src/components/DividendForm.test.jsx
@@ -77,10 +77,22 @@ test('does not expose normalized-colliding aliases in the input choices', () => 
       evidence: 'Issuer verified',
       confidence: 'high',
       status: 'confirmed'
+    },
+    {
+      source_input: 'Third Source',
+      matched_company_name: 'Source Name',
+      matched_ticker: 'GOOG',
+      market: 'NASDAQ',
+      sector: 'Technology',
+      industry: 'Internet Content',
+      evidence: 'Issuer verified',
+      confidence: 'high',
+      status: 'confirmed'
     }
   ]);
 
-  expect(choices).toEqual([]);
+  expect(choices).toEqual(expect.arrayContaining(['Third Source', 'GOOG']));
+  expect(choices).not.toContain('Source Name');
 });
 
 test('does not expose a company alias shared by different canonical tickers', () => {

--- a/src/components/DividendForm.test.jsx
+++ b/src/components/DividendForm.test.jsx
@@ -83,6 +83,36 @@ test('does not expose normalized-colliding aliases in the input choices', () => 
   expect(choices).toEqual([]);
 });
 
+test('does not expose a company alias shared by different canonical tickers', () => {
+  const choices = getVerifiedMatchChoices([
+    {
+      source_input: 'Source A',
+      matched_company_name: 'Shared Issuer',
+      matched_ticker: 'AAPL',
+      market: 'NASDAQ',
+      sector: 'Technology',
+      industry: 'Consumer Electronics',
+      evidence: 'Issuer verified',
+      confidence: 'high',
+      status: 'confirmed'
+    },
+    {
+      source_input: 'Source B',
+      matched_company_name: 'Shared Issuer',
+      matched_ticker: 'MSFT',
+      market: 'NASDAQ',
+      sector: 'Technology',
+      industry: 'Software',
+      evidence: 'Issuer verified',
+      confidence: 'high',
+      status: 'confirmed'
+    }
+  ]);
+
+  expect(choices).toEqual(expect.arrayContaining(['Source A', 'Source B', 'AAPL', 'MSFT']));
+  expect(choices).not.toContain('Shared Issuer');
+});
+
 test('keeps payment date set to today after submitting a dividend', async () => {
   jest.useFakeTimers();
   jest.setSystemTime(new Date(2026, 6, 24, 9, 0, 0));

--- a/src/components/PortfolioAnalysis.jsx
+++ b/src/components/PortfolioAnalysis.jsx
@@ -45,42 +45,23 @@ function PortfolioAnalysis() {
 
         const sourceInput = registeringRow.sourceInput.trim();
         const normalizedTicker = matchedTicker.trim().toUpperCase();
-        if (matchStatus === MATCH_STATUS.CONFIRMED
-            && (!normalizedTicker || !matchedCompanyName.trim() || !market.trim() || !newSector.trim() || !newIndustry.trim())) {
-            alert('확정 매칭에는 실제 종목명, 티커, 시장, 분류 정보가 모두 필요합니다.');
-            return;
-        }
-        if (matchStatus === MATCH_STATUS.CONFIRMED && confidence !== 'high') {
-            alert('확정 매칭은 신뢰 수준을 높음으로 기록해야 합니다.');
+        if (matchStatus === MATCH_STATUS.CONFIRMED) {
+            alert('확정 매칭은 검증된 migration에서만 등록할 수 있습니다.');
             return;
         }
 
         setIsSubmitting(true);
 
         try {
-            if (matchStatus === MATCH_STATUS.CONFIRMED) {
-                const { error: tickerError } = await supabase
-                    .from('tickers')
-                    .insert([{
-                        ticker: normalizedTicker,
-                        company_name_kr: matchedCompanyName.trim(),
-                        exchange: market.trim(),
-                        sector: newSector.trim(),
-                        industry: newIndustry.trim()
-                    }]);
-
-                if (tickerError && tickerError.code !== '23505') throw tickerError;
-            }
-
             const { error } = await supabase
                 .from('ticker_matches')
                 .upsert([{
                     source_input: sourceInput.toUpperCase(),
-                    matched_ticker: matchStatus === MATCH_STATUS.CONFIRMED ? normalizedTicker : null,
-                    matched_company_name: matchStatus === MATCH_STATUS.CONFIRMED ? matchedCompanyName.trim() : null,
-                    market: matchStatus === MATCH_STATUS.CONFIRMED ? market.trim() : null,
-                    sector: matchStatus === MATCH_STATUS.CONFIRMED ? newSector.trim() : null,
-                    industry: matchStatus === MATCH_STATUS.CONFIRMED ? newIndustry.trim() : null,
+                    matched_ticker: normalizedTicker || null,
+                    matched_company_name: matchedCompanyName.trim() || null,
+                    market: market.trim() || null,
+                    sector: newSector.trim() || null,
+                    industry: newIndustry.trim() || null,
                     status: matchStatus,
                     confidence,
                     evidence: evidence.trim(),
@@ -90,7 +71,7 @@ function PortfolioAnalysis() {
             if (error) {
                 throw error;
             } else {
-                alert(matchStatus === MATCH_STATUS.CONFIRMED ? '종목 매칭이 저장되었습니다.' : '수동 확인 대상으로 저장되었습니다.');
+                alert(matchStatus === MATCH_STATUS.UNMATCHED ? '미매칭 보류로 저장되었습니다.' : '수동 확인 대상으로 저장되었습니다.');
                 setRegisteringRow(null);
                 await refetch();
             }
@@ -146,12 +127,11 @@ function PortfolioAnalysis() {
                         <div style={{ marginBottom: '16px' }}>
                             <label style={{ fontSize: '0.8rem', color: '#666' }}>원본 입력값</label>
                             <div style={{ fontWeight: 'bold', fontSize: '1.1rem' }}>{registeringRow.sourceInput}</div>
-                            <p style={{ margin: '6px 0 0', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>확정 매칭만 분류와 배당 집계에 반영됩니다.</p>
+                            <p style={{ margin: '6px 0 0', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>검증된 확정 매칭만 분류와 배당 집계에 반영됩니다. 이 화면에서는 수동 확인 결과만 저장합니다.</p>
                         </div>
                         <label style={{ display: 'block', marginBottom: '12px' }}>
                             처리 상태
                             <select value={matchStatus} onChange={e => setMatchStatus(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }}>
-                                <option value={MATCH_STATUS.CONFIRMED}>확정 매칭</option>
                                 <option value={MATCH_STATUS.MANUAL_REVIEW}>수동 확인</option>
                                 <option value={MATCH_STATUS.UNMATCHED}>미매칭 보류</option>
                             </select>

--- a/src/components/PortfolioAnalysis.jsx
+++ b/src/components/PortfolioAnalysis.jsx
@@ -1,135 +1,119 @@
-import React, { useMemo, useState, useCallback } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { useDividendData } from '../hooks/useDividendData';
-import { PieChart, PlusCircle, AlertCircle, X, Check } from 'lucide-react';
+import { buildPortfolioSummary, MATCH_STATUS } from '../utils/tickerMatching';
+import { PieChart, AlertCircle, X } from 'lucide-react';
 import { supabase } from '../api/supabaseClient';
 
 ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels);
 
 function PortfolioAnalysis() {
-    const { data, tickersMap, exchangeRate, loading, refetch } = useDividendData();
+    const { data, tickersMap, tickerMatchesMap, exchangeRate, loading, refetch } = useDividendData();
 
-    const [registeringTicker, setRegisteringTicker] = useState(null);
-    const [newSector, setNewSector] = useState('ETF');
-    const [newIndustry, setNewIndustry] = useState('Multi-Sector');
+    const [registeringRow, setRegisteringRow] = useState(null);
+    const [matchStatus, setMatchStatus] = useState(MATCH_STATUS.MANUAL_REVIEW);
+    const [confidence, setConfidence] = useState('low');
+    const [matchedTicker, setMatchedTicker] = useState('');
+    const [matchedCompanyName, setMatchedCompanyName] = useState('');
+    const [market, setMarket] = useState('');
+    const [newSector, setNewSector] = useState('');
+    const [newIndustry, setNewIndustry] = useState('');
+    const [evidence, setEvidence] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
 
-    const handleOpenModal = (ticker) => {
-        setRegisteringTicker(ticker);
-        setNewSector('ETF');
-        setNewIndustry('Multi-Sector');
+    const handleOpenModal = (row) => {
+        const match = row.match || {};
+        setRegisteringRow(row);
+        setMatchStatus(match.status || MATCH_STATUS.MANUAL_REVIEW);
+        setConfidence(match.confidence || 'low');
+        setMatchedTicker(match.matched_ticker || '');
+        setMatchedCompanyName(match.matched_company_name || '');
+        setMarket(match.market || '');
+        setNewSector(match.sector || '');
+        setNewIndustry(match.industry || '');
+        setEvidence(match.evidence || '');
     };
 
     const handleCloseModal = () => {
-        setRegisteringTicker(null);
+        setRegisteringRow(null);
     };
 
     const handleRegister = async () => {
-        if (!registeringTicker || !newSector || !newIndustry) return;
+        if (!registeringRow || !evidence.trim()) return;
+
+        const sourceInput = registeringRow.sourceInput.trim();
+        const normalizedTicker = matchedTicker.trim().toUpperCase();
+        if (matchStatus === MATCH_STATUS.CONFIRMED
+            && (!normalizedTicker || !matchedCompanyName.trim() || !market.trim() || !newSector.trim() || !newIndustry.trim())) {
+            alert('확정 매칭에는 실제 종목명, 티커, 시장, 분류 정보가 모두 필요합니다.');
+            return;
+        }
+        if (matchStatus === MATCH_STATUS.CONFIRMED && confidence !== 'high') {
+            alert('확정 매칭은 신뢰 수준을 높음으로 기록해야 합니다.');
+            return;
+        }
 
         setIsSubmitting(true);
-        // Normalize the ticker being registered
-        const tickerToRegister = registeringTicker.trim();
 
         try {
-            console.log('Registering to DB:', { ticker: tickerToRegister, sector: newSector, industry: newIndustry });
+            if (matchStatus === MATCH_STATUS.CONFIRMED) {
+                const { error: tickerError } = await supabase
+                    .from('tickers')
+                    .insert([{
+                        ticker: normalizedTicker,
+                        company_name_kr: matchedCompanyName.trim(),
+                        exchange: market.trim(),
+                        sector: newSector.trim(),
+                        industry: newIndustry.trim()
+                    }]);
+
+                if (tickerError && tickerError.code !== '23505') throw tickerError;
+            }
 
             const { error } = await supabase
-                .from('tickers')
-                .insert([{
-                    ticker: tickerToRegister,
-                    sector: newSector.trim(),
-                    industry: newIndustry.trim()
-                }]);
+                .from('ticker_matches')
+                .upsert([{
+                    source_input: sourceInput.toUpperCase(),
+                    matched_ticker: matchStatus === MATCH_STATUS.CONFIRMED ? normalizedTicker : null,
+                    matched_company_name: matchStatus === MATCH_STATUS.CONFIRMED ? matchedCompanyName.trim() : null,
+                    market: matchStatus === MATCH_STATUS.CONFIRMED ? market.trim() : null,
+                    sector: matchStatus === MATCH_STATUS.CONFIRMED ? newSector.trim() : null,
+                    industry: matchStatus === MATCH_STATUS.CONFIRMED ? newIndustry.trim() : null,
+                    status: matchStatus,
+                    confidence,
+                    evidence: evidence.trim(),
+                    updated_at: new Date().toISOString()
+                }], { onConflict: 'source_input' });
 
             if (error) {
-                if (error.code === '23505') {
-                    alert('이미 등록된 종목입니다.');
-                } else {
-                    throw error;
-                }
+                throw error;
             } else {
-                alert(`'${tickerToRegister}' 종목이 성공적으로 등록되었습니다!`);
-                // Close modal first
-                setRegisteringTicker(null);
-
-                // CRITICAL: Delay refetch slightly or ensure it's called
-                console.log('Calling refetch...');
-                if (refetch) {
-                    await refetch();
-                    console.log('Refetch complete.');
-                }
+                alert(matchStatus === MATCH_STATUS.CONFIRMED ? '종목 매칭이 저장되었습니다.' : '수동 확인 대상으로 저장되었습니다.');
+                setRegisteringRow(null);
+                await refetch();
             }
         } catch (err) {
-            console.error('Registration error:', err);
-            alert('등록 중 오류가 발생했습니다: ' + err.message);
+            console.error('종목 매칭 저장 오류:', err);
+            alert('종목 매칭 저장 중 오류가 발생했습니다.');
         } finally {
             setIsSubmitting(false);
         }
     };
 
     const { sectorChartData, sectorTableData, unknownItems } = useMemo(() => {
-        const sectorMap = {};
-        const tickerAgg = {};
-
-        // Debug log to see what's being mapped
-        console.log('Recalculating weights with tickersMap:', Object.keys(tickersMap).length, 'items');
-
-        data.forEach(item => {
-            let amount = Number(item.dividend_amount) || 0;
-            if (item.currency === 'USD') amount = amount * exchangeRate;
-
-            let rawTicker = item.ticker || '';
-            let rawCompany = item.company_name || '';
-
-            // Normalize for lookup
-            let lookupKey = rawTicker.toUpperCase().trim();
-            if (!lookupKey && rawCompany) {
-                lookupKey = rawCompany.toUpperCase().trim();
-            }
-
-            const ticker = lookupKey || 'UNKNOWN';
-            if (!tickerAgg[ticker]) tickerAgg[ticker] = 0;
-            tickerAgg[ticker] += amount;
+        const summary = buildPortfolioSummary({
+            data,
+            exchangeRate,
+            tickerMatchesMap: tickerMatchesMap || {},
+            tickersMap
         });
-
-        Object.entries(tickerAgg).forEach(([ticker, amount]) => {
-            let sector = 'Unknown';
-            const normalizedTicker = ticker.toUpperCase().trim();
-
-            if (tickersMap[normalizedTicker]) {
-                sector = tickersMap[normalizedTicker].sector || 'Unknown';
-            }
-
-            if (!sectorMap[sector]) sectorMap[sector] = 0;
-            sectorMap[sector] += amount;
-        });
-
-        const categories = Object.keys(sectorMap).sort((a, b) => sectorMap[b] - sectorMap[a]);
-        const values = categories.map(c => sectorMap[c]);
-
-        const tableData = Object.entries(tickerAgg)
-            .map(([ticker, amount]) => {
-                const normalizedTicker = ticker.toUpperCase().trim();
-                const metadata = tickersMap[normalizedTicker];
-                return {
-                    ticker,
-                    amount,
-                    sector: metadata?.sector || 'Unknown',
-                    industry: metadata?.industry || '-'
-                };
-            })
-            .sort((a, b) => b.amount - a.amount);
-
-        const unknown = tableData.filter(row => row.sector === 'Unknown');
-
         return {
             sectorChartData: {
-                labels: categories,
+                labels: summary.sectorChartData.labels,
                 datasets: [{
-                    data: values,
+                    data: summary.sectorChartData.values,
                     backgroundColor: [
                         '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40',
                         '#8e44ad', '#34495e', '#2ecc71', '#e74c3c', '#95a5a6', '#7f8c8d'
@@ -137,10 +121,10 @@ function PortfolioAnalysis() {
                     borderWidth: 1,
                 }]
             },
-            sectorTableData: tableData,
-            unknownItems: unknown
+            sectorTableData: summary.sectorTableData,
+            unknownItems: summary.unknownItems
         };
-    }, [data, tickersMap, exchangeRate]);
+    }, [data, tickerMatchesMap, tickersMap, exchangeRate]);
 
     if (loading) return <div style={{ padding: '40px', textAlign: 'center' }}>데이터 로딩 중...</div>;
 
@@ -148,39 +132,66 @@ function PortfolioAnalysis() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', paddingBottom: '40px', position: 'relative' }}>
 
             {/* Modal */}
-            {registeringTicker && (
+            {registeringRow && (
                 <div style={{
                     position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
                     backgroundColor: 'rgba(0,0,0,0.6)', display: 'flex',
                     alignItems: 'center', justifyContent: 'center', zIndex: 9999
                 }}>
-                    <div className="card" style={{ width: '90%', maxWidth: '400px', padding: '24px' }}>
+                    <div className="card" style={{ width: '90%', maxWidth: '520px', padding: '24px', maxHeight: '90vh', overflowY: 'auto' }}>
                         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '20px' }}>
-                            <h3 style={{ margin: 0 }}>종목 정보 등록</h3>
+                            <h3 style={{ margin: 0 }}>종목 매칭 정보 확인</h3>
                             <button onClick={handleCloseModal} style={{ border: 'none', background: 'none', cursor: 'pointer' }}><X /></button>
                         </div>
                         <div style={{ marginBottom: '16px' }}>
-                            <label style={{ fontSize: '0.8rem', color: '#666' }}>등록할 종목명</label>
-                            <div style={{ fontWeight: 'bold', fontSize: '1.2rem' }}>{registeringTicker}</div>
+                            <label style={{ fontSize: '0.8rem', color: '#666' }}>원본 입력값</label>
+                            <div style={{ fontWeight: 'bold', fontSize: '1.1rem' }}>{registeringRow.sourceInput}</div>
+                            <p style={{ margin: '6px 0 0', color: 'var(--text-secondary)', fontSize: '0.85rem' }}>확정 매칭만 분류와 배당 집계에 반영됩니다.</p>
                         </div>
-                        <div style={{ marginBottom: '16px' }}>
-                            <label style={{ display: 'block', marginBottom: '8px' }}>섹터</label>
-                            <input
-                                type="text" value={newSector} onChange={e => setNewSector(e.target.value)}
-                                style={{ width: '100%', padding: '10px', borderRadius: '6px', border: '1px solid var(--border-color)', background: 'var(--bg-card)', color: 'var(--text-primary)' }}
-                            />
-                        </div>
-                        <div style={{ marginBottom: '24px' }}>
-                            <label style={{ display: 'block', marginBottom: '8px' }}>산업군</label>
-                            <input
-                                type="text" value={newIndustry} onChange={e => setNewIndustry(e.target.value)}
-                                style={{ width: '100%', padding: '10px', borderRadius: '6px', border: '1px solid var(--border-color)', background: 'var(--bg-card)', color: 'var(--text-primary)' }}
-                            />
-                        </div>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            처리 상태
+                            <select value={matchStatus} onChange={e => setMatchStatus(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }}>
+                                <option value={MATCH_STATUS.CONFIRMED}>확정 매칭</option>
+                                <option value={MATCH_STATUS.MANUAL_REVIEW}>수동 확인</option>
+                                <option value={MATCH_STATUS.UNMATCHED}>미매칭 보류</option>
+                            </select>
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            신뢰 수준
+                            <select value={confidence} onChange={e => setConfidence(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }}>
+                                <option value="high">높음</option>
+                                <option value="medium">중간</option>
+                                <option value="low">낮음</option>
+                            </select>
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            실제 종목명
+                            <input type="text" value={matchedCompanyName} onChange={e => setMatchedCompanyName(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }} />
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            실제 티커
+                            <input type="text" value={matchedTicker} onChange={e => setMatchedTicker(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }} />
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            시장
+                            <input type="text" value={market} onChange={e => setMarket(e.target.value)} placeholder="예: NASDAQ, KOSPI" style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }} />
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            섹터
+                            <input type="text" value={newSector} onChange={e => setNewSector(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }} />
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '12px' }}>
+                            산업군
+                            <input type="text" value={newIndustry} onChange={e => setNewIndustry(e.target.value)} style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px' }} />
+                        </label>
+                        <label style={{ display: 'block', marginBottom: '24px' }}>
+                            매칭 근거
+                            <textarea value={evidence} onChange={e => setEvidence(e.target.value)} required rows={3} placeholder="공식 거래소·발행사·공시 등 확인 가능한 근거를 기록하세요." style={{ display: 'block', width: '100%', marginTop: '6px', padding: '10px', resize: 'vertical' }} />
+                        </label>
                         <div style={{ display: 'flex', gap: '10px' }}>
                             <button onClick={handleCloseModal} style={{ flex: 1, padding: '12px', borderRadius: '8px', border: '1px solid var(--border-color)', background: 'none', cursor: 'pointer' }}>취소</button>
-                            <button onClick={handleRegister} disabled={isSubmitting} style={{ flex: 1, padding: '12px', borderRadius: '8px', border: 'none', backgroundColor: 'var(--accent-color)', color: '#fff', fontWeight: 'bold', cursor: 'pointer' }}>
-                                {isSubmitting ? '처리 중...' : '등록 완료'}
+                            <button onClick={handleRegister} disabled={isSubmitting || !evidence.trim()} style={{ flex: 1, padding: '12px', borderRadius: '8px', border: 'none', backgroundColor: 'var(--accent-color)', color: '#fff', fontWeight: 'bold', cursor: 'pointer' }}>
+                                {isSubmitting ? '처리 중...' : '매칭 정보 저장'}
                             </button>
                         </div>
                     </div>
@@ -287,7 +298,9 @@ function PortfolioAnalysis() {
                         <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
                             <thead>
                                 <tr style={{ borderBottom: '2px solid var(--border-color)', textAlign: 'left' }}>
-                                    <th style={{ padding: '12px' }}>종목명(티커)</th>
+                                    <th style={{ padding: '12px' }}>원본 입력값</th>
+                                    <th style={{ padding: '12px' }}>확인 후보</th>
+                                    <th style={{ padding: '12px' }}>상태</th>
                                     <th style={{ padding: '12px', textAlign: 'right' }}>누적 배당금</th>
                                     <th style={{ padding: '12px', textAlign: 'center' }}>조치</th>
                                 </tr>
@@ -295,12 +308,14 @@ function PortfolioAnalysis() {
                             <tbody>
                                 {unknownItems.map((row, idx) => (
                                     <tr key={idx} style={{ borderBottom: '1px solid var(--border-color)' }}>
-                                        <td style={{ padding: '12px', fontWeight: 'bold' }}>{row.ticker}</td>
+                                        <td style={{ padding: '12px', fontWeight: 'bold' }}>{row.sourceInput || row.ticker}</td>
+                                        <td style={{ padding: '12px' }}>{row.match?.matched_company_name || '-'}{row.match?.matched_ticker ? ` (${row.match.matched_ticker})` : ''}</td>
+                                        <td style={{ padding: '12px' }}>{row.matchStatus === MATCH_STATUS.MANUAL_REVIEW ? '수동 확인' : row.matchStatus === MATCH_STATUS.UNMATCHED ? '미매칭 보류' : '미확인'}</td>
                                         <td style={{ padding: '12px', textAlign: 'right' }}>₩ {Math.round(row.amount).toLocaleString()}</td>
                                         <td style={{ padding: '12px', textAlign: 'center' }}>
                                             <button
                                                 type="button"
-                                                onClick={() => handleOpenModal(row.ticker)}
+                                                onClick={() => handleOpenModal(row)}
                                                 style={{
                                                     padding: '6px 12px', fontSize: '0.8rem', backgroundColor: '#e74a3b', color: '#fff',
                                                     border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold'

--- a/src/hooks/useDividendData.js
+++ b/src/hooks/useDividendData.js
@@ -52,7 +52,7 @@ export function useDividendData() {
 
             const { data: matchData, error: matchError } = await supabase
                 .from('ticker_matches')
-                .select('*');
+                .select('source_input, matched_company_name, matched_ticker, market, sector, industry, evidence, confidence, status');
             if (matchError) {
                 console.warn('종목 매칭 정보 조회 오류:', matchError.message);
                 setTickerMatchesMap({});

--- a/src/hooks/useDividendData.js
+++ b/src/hooks/useDividendData.js
@@ -7,6 +7,7 @@ export function useDividendData() {
     const [error, setError] = useState(null);
     const [exchangeRate, setExchangeRate] = useState(1300);
     const [tickersMap, setTickersMap] = useState({});
+    const [tickerMatchesMap, setTickerMatchesMap] = useState({});
 
     const fetchExchangeRate = async () => {
         try {
@@ -48,6 +49,20 @@ export function useDividendData() {
             });
             setTickersMap(tMap);
 
+            const { data: matchData, error: matchError } = await supabase
+                .from('ticker_matches')
+                .select('*');
+            if (matchError) {
+                console.warn('종목 매칭 정보 조회 오류:', matchError.message);
+                setTickerMatchesMap({});
+            } else {
+                const matchMap = {};
+                (matchData || []).forEach(match => {
+                    if (match.source_input) matchMap[match.source_input.toUpperCase().trim()] = match;
+                });
+                setTickerMatchesMap(matchMap);
+            }
+
         } catch (err) {
             console.error('Error fetching dividend data:', err);
             setError(err);
@@ -60,5 +75,5 @@ export function useDividendData() {
         fetchData();
     }, [fetchData]);
 
-    return { data, loading, error, exchangeRate, tickersMap, refetch: fetchData };
+    return { data, loading, error, exchangeRate, tickersMap, tickerMatchesMap, refetch: fetchData };
 }

--- a/src/hooks/useDividendData.js
+++ b/src/hooks/useDividendData.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../api/supabaseClient';
+import { buildTickerMatchesMap } from '../utils/tickerMatching';
 
 export function useDividendData() {
     const [data, setData] = useState([]);
@@ -56,11 +57,7 @@ export function useDividendData() {
                 console.warn('종목 매칭 정보 조회 오류:', matchError.message);
                 setTickerMatchesMap({});
             } else {
-                const matchMap = {};
-                (matchData || []).forEach(match => {
-                    if (match.source_input) matchMap[match.source_input.toUpperCase().trim()] = match;
-                });
-                setTickerMatchesMap(matchMap);
+                setTickerMatchesMap(buildTickerMatchesMap(matchData));
             }
 
         } catch (err) {

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -59,10 +59,14 @@ export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exch
     .map(({ ticker, amount, sourceInputs, sourceCompanyNames, resolution }) => {
       const match = resolution.match;
       const metadata = resolution.metadata;
-      const sector = metadata?.sector || (resolution.isConfirmed ? match?.sector : null) || 'Unknown';
-      const industry = metadata?.industry || (resolution.isConfirmed ? match?.industry : null) || '-';
+      const sector = resolution.isConfirmed
+        ? metadata?.sector || match?.sector || 'Unknown'
+        : 'Unknown';
+      const industry = resolution.isConfirmed
+        ? metadata?.industry || match?.industry || '-'
+        : '-';
       const companyName = (resolution.isConfirmed && match?.matched_company_name)
-        || metadata?.company_name_kr
+        || (resolution.isConfirmed && metadata?.company_name_kr)
         || [...sourceCompanyNames][0]
         || ticker;
 
@@ -72,7 +76,7 @@ export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exch
         companyName,
         sector,
         industry,
-        market: metadata?.exchange || (resolution.isConfirmed ? match?.market : null) || '-',
+        market: resolution.isConfirmed ? metadata?.exchange || match?.market || '-' : '-',
         sourceInput: [...sourceInputs][0] || '',
         sourceInputs: [...sourceInputs],
         sourceCompanyNames: [...sourceCompanyNames],

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -8,6 +8,37 @@ export function normalizeTickerInput(value) {
   return typeof value === 'string' ? value.trim().toUpperCase() : '';
 }
 
+export function isVerifiedMatch(match) {
+  return match?.status === MATCH_STATUS.CONFIRMED
+    && match?.confidence === 'high'
+    && Boolean(normalizeTickerInput(match?.matched_ticker))
+    && [
+      match?.matched_company_name,
+      match?.market,
+      match?.sector,
+      match?.industry,
+      match?.evidence,
+    ].every((value) => Boolean(String(value || '').trim()));
+}
+
+export function buildTickerMatchesMap(matches) {
+  const matchMap = {};
+
+  (matches || []).forEach((match) => {
+    const sourceKey = normalizeTickerInput(match?.source_input);
+    if (!sourceKey) return;
+
+    if (Object.prototype.hasOwnProperty.call(matchMap, sourceKey)) {
+      matchMap[sourceKey] = null;
+      return;
+    }
+
+    matchMap[sourceKey] = match;
+  });
+
+  return matchMap;
+}
+
 function getSourceInput(item) {
   return String(item.ticker || item.company_name || '').trim();
 }
@@ -18,7 +49,7 @@ function getMatch(item, tickerMatchesMap) {
   if (directMatch) return directMatch;
 
   const aliasMatches = Object.values(tickerMatchesMap).filter((match) => (
-    match.status === MATCH_STATUS.CONFIRMED
+    isVerifiedMatch(match)
     && [match.matched_ticker, match.matched_company_name]
       .some((alias) => normalizeTickerInput(alias) === sourceKey)
   ));
@@ -31,17 +62,7 @@ export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
   const sourceKey = normalizeTickerInput(sourceInput);
   const match = getMatch(item, tickerMatchesMap);
   const matchedTicker = normalizeTickerInput(match?.matched_ticker);
-  const hasVerifiedDetails = [
-    match?.matched_company_name,
-    match?.market,
-    match?.sector,
-    match?.industry,
-    match?.evidence,
-  ].every((value) => Boolean(String(value || '').trim()));
-  const isConfirmed = match?.status === MATCH_STATUS.CONFIRMED
-    && match?.confidence === 'high'
-    && Boolean(matchedTicker)
-    && hasVerifiedDetails;
+  const isConfirmed = isVerifiedMatch(match);
   const isBlocked = !isConfirmed;
   const resolvedTicker = isConfirmed ? matchedTicker : sourceKey || 'UNKNOWN';
   const metadata = isConfirmed ? tickersMap[resolvedTicker] || null : null;

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -23,6 +23,7 @@ export function isVerifiedMatch(match) {
 
 export function buildTickerMatchesMap(matches) {
   const matchMap = {};
+  const blockedSourceKeys = new Set();
 
   (matches || []).forEach((match) => {
     const sourceKey = normalizeTickerInput(match?.source_input);
@@ -30,13 +31,46 @@ export function buildTickerMatchesMap(matches) {
 
     if (Object.prototype.hasOwnProperty.call(matchMap, sourceKey)) {
       matchMap[sourceKey] = null;
+      blockedSourceKeys.add(sourceKey);
       return;
     }
 
     matchMap[sourceKey] = match;
   });
 
+  Object.defineProperty(matchMap, '__blockedSourceKeys', {
+    value: blockedSourceKeys,
+    enumerable: false,
+  });
   return matchMap;
+}
+
+function getBlockedSourceKeys(tickerMatchesMap) {
+  return tickerMatchesMap?.__blockedSourceKeys instanceof Set
+    ? tickerMatchesMap.__blockedSourceKeys
+    : new Set();
+}
+
+export function getVerifiedMatchAliasKeys(tickerMatchesMap) {
+  const aliasTickers = new Map();
+
+  Object.entries(tickerMatchesMap).filter(([, match]) => isVerifiedMatch(match)).forEach(([sourceKey, match]) => {
+    const matchedTicker = normalizeTickerInput(match.matched_ticker);
+    [sourceKey, match.source_input, match.matched_company_name, match.matched_ticker].forEach((alias) => {
+      const aliasKey = normalizeTickerInput(alias);
+      if (!aliasKey) return;
+      const tickers = aliasTickers.get(aliasKey) || new Set();
+      tickers.add(matchedTicker);
+      aliasTickers.set(aliasKey, tickers);
+    });
+  });
+
+  const blockedSourceKeys = getBlockedSourceKeys(tickerMatchesMap);
+  return new Set(
+    [...aliasTickers.entries()]
+      .filter(([aliasKey, tickers]) => tickers.size === 1 && !blockedSourceKeys.has(aliasKey))
+      .map(([aliasKey]) => aliasKey)
+  );
 }
 
 function getSourceInput(item) {
@@ -46,13 +80,19 @@ function getSourceInput(item) {
 function getMatch(item, tickerMatchesMap) {
   const sourceKey = normalizeTickerInput(getSourceInput(item));
   const directMatch = tickerMatchesMap[sourceKey];
-  if (directMatch) return directMatch;
+  if (directMatch && !isVerifiedMatch(directMatch)) return directMatch;
+
+  const verifiedAliases = getVerifiedMatchAliasKeys(tickerMatchesMap);
+  if (!verifiedAliases.has(sourceKey)) return null;
 
   const aliasMatches = Object.values(tickerMatchesMap).filter((match) => (
     isVerifiedMatch(match)
-    && [match.matched_ticker, match.matched_company_name]
+    && [match.source_input, match.matched_ticker, match.matched_company_name]
       .some((alias) => normalizeTickerInput(alias) === sourceKey)
   ));
+  if (directMatch && isVerifiedMatch(directMatch) && !aliasMatches.includes(directMatch)) {
+    aliasMatches.push(directMatch);
+  }
   const matchedTickers = [...new Set(aliasMatches.map((match) => normalizeTickerInput(match.matched_ticker)).filter(Boolean))];
   return matchedTickers.length === 1 ? aliasMatches[0] : null;
 }

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -1,0 +1,101 @@
+export const MATCH_STATUS = Object.freeze({
+  CONFIRMED: 'confirmed',
+  MANUAL_REVIEW: 'manual_review',
+  UNMATCHED: 'unmatched',
+});
+
+export function normalizeTickerInput(value) {
+  return typeof value === 'string' ? value.trim().toUpperCase() : '';
+}
+
+function getSourceInput(item) {
+  return String(item.ticker || item.company_name || '').trim();
+}
+
+function getMatch(item, tickerMatchesMap) {
+  return tickerMatchesMap[normalizeTickerInput(getSourceInput(item))] || null;
+}
+
+export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
+  const sourceInput = getSourceInput(item);
+  const sourceKey = normalizeTickerInput(sourceInput);
+  const match = getMatch(item, tickerMatchesMap);
+  const matchedTicker = normalizeTickerInput(match?.matched_ticker);
+  const isConfirmed = match?.status === MATCH_STATUS.CONFIRMED && Boolean(matchedTicker);
+  const resolvedTicker = isConfirmed ? matchedTicker : sourceKey || 'UNKNOWN';
+  const metadata = tickersMap[resolvedTicker] || null;
+
+  return {
+    sourceInput,
+    sourceKey,
+    match,
+    isConfirmed,
+    resolvedTicker,
+    metadata,
+  };
+}
+
+export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exchangeRate }) {
+  const tickerAggregates = new Map();
+
+  data.forEach((item) => {
+    const amount = (Number(item.dividend_amount) || 0) * (item.currency === 'USD' ? exchangeRate : 1);
+    const resolution = resolveInstrument(item, tickerMatchesMap, tickersMap);
+    const current = tickerAggregates.get(resolution.resolvedTicker) || {
+      ticker: resolution.resolvedTicker,
+      amount: 0,
+      sourceInputs: new Set(),
+      sourceCompanyNames: new Set(),
+      resolution,
+    };
+
+    current.amount += amount;
+    if (resolution.sourceInput) current.sourceInputs.add(resolution.sourceInput);
+    if (item.company_name) current.sourceCompanyNames.add(item.company_name);
+    tickerAggregates.set(resolution.resolvedTicker, current);
+  });
+
+  const tableData = [...tickerAggregates.values()]
+    .map(({ ticker, amount, sourceInputs, sourceCompanyNames, resolution }) => {
+      const match = resolution.match;
+      const metadata = resolution.metadata;
+      const sector = metadata?.sector || (resolution.isConfirmed ? match?.sector : null) || 'Unknown';
+      const industry = metadata?.industry || (resolution.isConfirmed ? match?.industry : null) || '-';
+      const companyName = (resolution.isConfirmed && match?.matched_company_name)
+        || metadata?.company_name_kr
+        || [...sourceCompanyNames][0]
+        || ticker;
+
+      return {
+        ticker,
+        amount,
+        companyName,
+        sector,
+        industry,
+        market: metadata?.exchange || (resolution.isConfirmed ? match?.market : null) || '-',
+        sourceInput: [...sourceInputs][0] || '',
+        sourceInputs: [...sourceInputs],
+        sourceCompanyNames: [...sourceCompanyNames],
+        match,
+        matchStatus: match?.status || null,
+        confidence: match?.confidence || null,
+        evidence: match?.evidence || null,
+      };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  const sectorMap = tableData.reduce((result, row) => {
+    result[row.sector] = (result[row.sector] || 0) + row.amount;
+    return result;
+  }, {});
+  const categories = Object.keys(sectorMap).sort((a, b) => sectorMap[b] - sectorMap[a]);
+
+  return {
+    sectorChartData: {
+      labels: categories,
+      values: categories.map((category) => sectorMap[category]),
+    },
+    sectorTableData: tableData,
+    unknownItems: tableData.filter((row) => row.sector === 'Unknown'),
+  };
+}

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -31,7 +31,17 @@ export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
   const sourceKey = normalizeTickerInput(sourceInput);
   const match = getMatch(item, tickerMatchesMap);
   const matchedTicker = normalizeTickerInput(match?.matched_ticker);
-  const isConfirmed = match?.status === MATCH_STATUS.CONFIRMED && Boolean(matchedTicker);
+  const hasVerifiedDetails = [
+    match?.matched_company_name,
+    match?.market,
+    match?.sector,
+    match?.industry,
+    match?.evidence,
+  ].every((value) => Boolean(String(value || '').trim()));
+  const isConfirmed = match?.status === MATCH_STATUS.CONFIRMED
+    && match?.confidence === 'high'
+    && Boolean(matchedTicker)
+    && hasVerifiedDetails;
   const isBlocked = !isConfirmed;
   const resolvedTicker = isConfirmed ? matchedTicker : sourceKey || 'UNKNOWN';
   const metadata = isConfirmed ? tickersMap[resolvedTicker] || null : null;

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -13,7 +13,17 @@ function getSourceInput(item) {
 }
 
 function getMatch(item, tickerMatchesMap) {
-  return tickerMatchesMap[normalizeTickerInput(getSourceInput(item))] || null;
+  const sourceKey = normalizeTickerInput(getSourceInput(item));
+  const directMatch = tickerMatchesMap[sourceKey];
+  if (directMatch) return directMatch;
+
+  const aliasMatches = Object.values(tickerMatchesMap).filter((match) => (
+    match.status === MATCH_STATUS.CONFIRMED
+    && [match.matched_ticker, match.matched_company_name]
+      .some((alias) => normalizeTickerInput(alias) === sourceKey)
+  ));
+  const matchedTickers = [...new Set(aliasMatches.map((match) => normalizeTickerInput(match.matched_ticker)).filter(Boolean))];
+  return matchedTickers.length === 1 ? aliasMatches[0] : null;
 }
 
 export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
@@ -22,6 +32,7 @@ export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
   const match = getMatch(item, tickerMatchesMap);
   const matchedTicker = normalizeTickerInput(match?.matched_ticker);
   const isConfirmed = match?.status === MATCH_STATUS.CONFIRMED && Boolean(matchedTicker);
+  const isBlocked = Boolean(match) && !isConfirmed;
   const resolvedTicker = isConfirmed ? matchedTicker : sourceKey || 'UNKNOWN';
   const metadata = tickersMap[resolvedTicker] || null;
 
@@ -30,6 +41,7 @@ export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
     sourceKey,
     match,
     isConfirmed,
+    isBlocked,
     resolvedTicker,
     metadata,
   };
@@ -41,7 +53,10 @@ export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exch
   data.forEach((item) => {
     const amount = (Number(item.dividend_amount) || 0) * (item.currency === 'USD' ? exchangeRate : 1);
     const resolution = resolveInstrument(item, tickerMatchesMap, tickersMap);
-    const current = tickerAggregates.get(resolution.resolvedTicker) || {
+    const aggregationKey = resolution.isBlocked
+      ? `unconfirmed:${resolution.sourceKey || 'UNKNOWN'}`
+      : `instrument:${resolution.resolvedTicker}`;
+    const current = tickerAggregates.get(aggregationKey) || {
       ticker: resolution.resolvedTicker,
       amount: 0,
       sourceInputs: new Set(),
@@ -52,21 +67,25 @@ export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exch
     current.amount += amount;
     if (resolution.sourceInput) current.sourceInputs.add(resolution.sourceInput);
     if (item.company_name) current.sourceCompanyNames.add(item.company_name);
-    tickerAggregates.set(resolution.resolvedTicker, current);
+    tickerAggregates.set(aggregationKey, current);
   });
 
   const tableData = [...tickerAggregates.values()]
     .map(({ ticker, amount, sourceInputs, sourceCompanyNames, resolution }) => {
       const match = resolution.match;
       const metadata = resolution.metadata;
-      const sector = resolution.isConfirmed
-        ? metadata?.sector || match?.sector || 'Unknown'
-        : 'Unknown';
-      const industry = resolution.isConfirmed
-        ? metadata?.industry || match?.industry || '-'
-        : '-';
+      const sector = resolution.isBlocked
+        ? 'Unknown'
+        : resolution.isConfirmed
+          ? match?.sector || metadata?.sector || 'Unknown'
+          : metadata?.sector || 'Unknown';
+      const industry = resolution.isBlocked
+        ? '-'
+        : resolution.isConfirmed
+          ? match?.industry || metadata?.industry || '-'
+          : metadata?.industry || '-';
       const companyName = (resolution.isConfirmed && match?.matched_company_name)
-        || (resolution.isConfirmed && metadata?.company_name_kr)
+        || metadata?.company_name_kr
         || [...sourceCompanyNames][0]
         || ticker;
 
@@ -76,7 +95,11 @@ export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exch
         companyName,
         sector,
         industry,
-        market: resolution.isConfirmed ? metadata?.exchange || match?.market || '-' : '-',
+        market: resolution.isBlocked
+          ? '-'
+          : resolution.isConfirmed
+            ? match?.market || metadata?.exchange || '-'
+            : metadata?.exchange || '-',
         sourceInput: [...sourceInputs][0] || '',
         sourceInputs: [...sourceInputs],
         sourceCompanyNames: [...sourceCompanyNames],

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -32,9 +32,9 @@ export function resolveInstrument(item, tickerMatchesMap, tickersMap) {
   const match = getMatch(item, tickerMatchesMap);
   const matchedTicker = normalizeTickerInput(match?.matched_ticker);
   const isConfirmed = match?.status === MATCH_STATUS.CONFIRMED && Boolean(matchedTicker);
-  const isBlocked = Boolean(match) && !isConfirmed;
+  const isBlocked = !isConfirmed;
   const resolvedTicker = isConfirmed ? matchedTicker : sourceKey || 'UNKNOWN';
-  const metadata = tickersMap[resolvedTicker] || null;
+  const metadata = isConfirmed ? tickersMap[resolvedTicker] || null : null;
 
   return {
     sourceInput,

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -40,6 +40,89 @@ describe('buildPortfolioSummary', () => {
     ]);
   });
 
+  test('does not let a third alias re-enter a quarantined source collision', () => {
+    const tickerMatchesMap = buildTickerMatchesMap([
+      {
+        source_input: 'Alias',
+        matched_ticker: 'AAPL',
+        matched_company_name: 'Apple Inc.',
+        market: 'NASDAQ',
+        sector: 'Technology',
+        industry: 'Consumer Electronics',
+        status: 'confirmed',
+        confidence: 'high',
+        evidence: 'Issuer verified',
+      },
+      {
+        source_input: ' alias ',
+        matched_ticker: 'MSFT',
+        matched_company_name: 'Microsoft Corporation',
+        market: 'NASDAQ',
+        sector: 'Technology',
+        industry: 'Software',
+        status: 'confirmed',
+        confidence: 'high',
+        evidence: 'Issuer verified',
+      },
+      {
+        source_input: 'THIRD',
+        matched_ticker: 'ALIAS',
+        matched_company_name: 'Third Corporation',
+        market: 'NASDAQ',
+        sector: 'Technology',
+        industry: 'Software',
+        status: 'confirmed',
+        confidence: 'high',
+        evidence: 'Issuer verified',
+      },
+    ]);
+
+    const result = buildPortfolioSummary({
+      data: [{ company_name: 'Alias', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap,
+      tickersMap: {},
+    });
+
+    expect(result.unknownItems).toHaveLength(1);
+    expect(result.sectorTableData[0].ticker).toBe('ALIAS');
+  });
+
+  test('does not resolve a direct alias shared across canonical tickers', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'SHARED', company_name: 'Shared', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        SHARED: {
+          source_input: 'SHARED',
+          matched_ticker: 'AAPL',
+          matched_company_name: 'Apple Inc.',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Consumer Electronics',
+          status: 'confirmed',
+          confidence: 'high',
+          evidence: 'Issuer verified',
+        },
+        OTHER: {
+          source_input: 'OTHER',
+          matched_ticker: 'MSFT',
+          matched_company_name: 'SHARED',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Software',
+          status: 'confirmed',
+          confidence: 'high',
+          evidence: 'Issuer verified',
+        },
+      },
+      tickersMap: {},
+    });
+
+    expect(result.unknownItems).toHaveLength(1);
+    expect(result.sectorTableData[0].ticker).toBe('SHARED');
+  });
+
   test('uses only confirmed matches for canonical aggregation', () => {
     const result = buildPortfolioSummary({
       data: [

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -134,6 +134,23 @@ describe('buildPortfolioSummary', () => {
     ]);
   });
 
+  test('does not classify an incomplete legacy confirmed row', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'LEGACY', company_name: 'Legacy', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        LEGACY: { status: 'confirmed', matched_ticker: 'AAPL', confidence: 'high', evidence: '' },
+      },
+      tickersMap: {
+        AAPL: { ticker: 'AAPL', sector: 'Technology', industry: 'Consumer Electronics' },
+      },
+    });
+
+    expect(result.unknownItems).toEqual([
+      expect.objectContaining({ ticker: 'LEGACY', sector: 'Unknown', matchStatus: 'confirmed' }),
+    ]);
+  });
+
   test('does not merge an unconfirmed source into a confirmed canonical ticker', () => {
     const result = buildPortfolioSummary({
       data: [

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -119,6 +119,21 @@ describe('buildPortfolioSummary', () => {
     ]);
   });
 
+  test('does not classify an input without a match from existing ticker metadata', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'CATALOG ONLY', company_name: 'Catalog only', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {},
+      tickersMap: {
+        'CATALOG ONLY': { ticker: 'CATALOG ONLY', sector: 'Mutable sector', industry: 'Mutable industry' },
+      },
+    });
+
+    expect(result.unknownItems).toEqual([
+      expect.objectContaining({ ticker: 'CATALOG ONLY', sector: 'Unknown', industry: '-' }),
+    ]);
+  });
+
   test('does not merge an unconfirmed source into a confirmed canonical ticker', () => {
     const result = buildPortfolioSummary({
       data: [

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -22,7 +22,7 @@ describe('buildPortfolioSummary', () => {
         },
       },
       tickersMap: {
-        AAPL: { ticker: 'AAPL', sector: 'Technology', industry: 'Consumer Electronics' },
+        AAPL: { ticker: 'AAPL', sector: 'Mutable wrong sector', industry: 'Mutable wrong industry' },
       },
     });
 
@@ -37,6 +37,32 @@ describe('buildPortfolioSummary', () => {
       }),
     ]);
     expect(result.unknownItems).toHaveLength(0);
+  });
+
+  test('resolves a confirmed company-name alias selected from the input list', () => {
+    const result = buildPortfolioSummary({
+      data: [{ company_name: 'Apple Inc.', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        'LEGACY FUND': {
+          matched_ticker: 'AAPL',
+          matched_company_name: 'Apple Inc.',
+          status: 'confirmed',
+          confidence: 'high',
+          evidence: 'Issuer verified',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Consumer Electronics',
+        },
+      },
+      tickersMap: {},
+    });
+
+    expect(result.sectorTableData[0]).toEqual(expect.objectContaining({
+      ticker: 'AAPL',
+      companyName: 'Apple Inc.',
+      sector: 'Technology',
+    }));
   });
 
   test('keeps manual-review matches in the original unknown bucket', () => {
@@ -91,5 +117,42 @@ describe('buildPortfolioSummary', () => {
     expect(result.unknownItems).toEqual([
       expect.objectContaining({ ticker: 'AMBIGUOUS', sector: 'Unknown', industry: '-' }),
     ]);
+  });
+
+  test('does not merge an unconfirmed source into a confirmed canonical ticker', () => {
+    const result = buildPortfolioSummary({
+      data: [
+        { ticker: 'LEGACY NAME', company_name: 'Legacy name', dividend_amount: 100, currency: 'KRW' },
+        { ticker: 'AAPL', company_name: 'AAPL', dividend_amount: 50, currency: 'KRW' },
+      ],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        'LEGACY NAME': {
+          status: 'confirmed',
+          matched_ticker: 'AAPL',
+          matched_company_name: 'Apple Inc.',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Consumer Electronics',
+          confidence: 'high',
+          evidence: 'Issuer verified',
+        },
+        AAPL: {
+          status: 'manual_review',
+          matched_ticker: 'AAPL',
+          confidence: 'medium',
+          evidence: 'Needs confirmation',
+        },
+      },
+      tickersMap: {
+        AAPL: { ticker: 'AAPL', sector: 'Technology', industry: 'Consumer Electronics' },
+      },
+    });
+
+    expect(result.sectorTableData).toEqual(expect.arrayContaining([
+      expect.objectContaining({ ticker: 'AAPL', amount: 100, sector: 'Technology', industry: 'Consumer Electronics' }),
+      expect.objectContaining({ ticker: 'AAPL', amount: 50, sector: 'Unknown', matchStatus: 'manual_review' }),
+    ]));
+    expect(result.unknownItems).toHaveLength(1);
   });
 });

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -1,6 +1,45 @@
-import { buildPortfolioSummary } from './tickerMatching';
+import { buildPortfolioSummary, buildTickerMatchesMap } from './tickerMatching';
 
 describe('buildPortfolioSummary', () => {
+  test('fails closed when normalized source aliases collide', () => {
+    const tickerMatchesMap = buildTickerMatchesMap([
+      {
+        source_input: 'Source Name',
+        matched_ticker: 'AAPL',
+        matched_company_name: 'Apple Inc.',
+        market: 'NASDAQ',
+        sector: 'Technology',
+        industry: 'Consumer Electronics',
+        status: 'confirmed',
+        confidence: 'high',
+        evidence: 'Issuer verified',
+      },
+      {
+        source_input: ' source name ',
+        matched_ticker: 'MSFT',
+        matched_company_name: 'Microsoft Corporation',
+        market: 'NASDAQ',
+        sector: 'Technology',
+        industry: 'Software',
+        status: 'confirmed',
+        confidence: 'high',
+        evidence: 'Issuer verified',
+      },
+    ]);
+
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'SOURCE NAME', company_name: 'Source Name', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap,
+      tickersMap: {},
+    });
+
+    expect(tickerMatchesMap['SOURCE NAME']).toBeNull();
+    expect(result.unknownItems).toEqual([
+      expect.objectContaining({ ticker: 'SOURCE NAME', sector: 'Unknown' }),
+    ]);
+  });
+
   test('uses only confirmed matches for canonical aggregation', () => {
     const result = buildPortfolioSummary({
       data: [
@@ -149,6 +188,29 @@ describe('buildPortfolioSummary', () => {
     expect(result.unknownItems).toEqual([
       expect.objectContaining({ ticker: 'LEGACY', sector: 'Unknown', matchStatus: 'confirmed' }),
     ]);
+  });
+
+  test('ignores incomplete confirmed aliases when resolving a verified alias', () => {
+    const result = buildPortfolioSummary({
+      data: [{ company_name: 'Apple Inc.', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        LEGACY: { status: 'confirmed', matched_ticker: 'AAPL', confidence: 'high', evidence: '' },
+        VERIFIED: {
+          status: 'confirmed',
+          matched_ticker: 'AAPL',
+          matched_company_name: 'Apple Inc.',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Consumer Electronics',
+          confidence: 'high',
+          evidence: 'Issuer verified',
+        },
+      },
+      tickersMap: {},
+    });
+
+    expect(result.sectorTableData[0]).toEqual(expect.objectContaining({ ticker: 'AAPL', sector: 'Technology' }));
   });
 
   test('does not merge an unconfirmed source into a confirmed canonical ticker', () => {

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -1,0 +1,73 @@
+import { buildPortfolioSummary } from './tickerMatching';
+
+describe('buildPortfolioSummary', () => {
+  test('uses only confirmed matches for canonical aggregation', () => {
+    const result = buildPortfolioSummary({
+      data: [
+        { ticker: 'legacy fund', company_name: 'Legacy fund', dividend_amount: 100, currency: 'KRW' },
+        { ticker: 'legacy fund', company_name: 'Legacy fund', dividend_amount: 25, currency: 'USD' },
+      ],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        'LEGACY FUND': {
+          source_input: 'LEGACY FUND',
+          matched_ticker: 'AAPL',
+          matched_company_name: 'Apple Inc.',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Consumer Electronics',
+          status: 'confirmed',
+          confidence: 'high',
+          evidence: 'Exchange listing verified',
+        },
+      },
+      tickersMap: {
+        AAPL: { ticker: 'AAPL', sector: 'Technology', industry: 'Consumer Electronics' },
+      },
+    });
+
+    expect(result.sectorTableData).toEqual([
+      expect.objectContaining({
+        ticker: 'AAPL',
+        companyName: 'Apple Inc.',
+        sector: 'Technology',
+        industry: 'Consumer Electronics',
+        amount: 32600,
+        sourceInputs: ['legacy fund'],
+      }),
+    ]);
+    expect(result.unknownItems).toHaveLength(0);
+  });
+
+  test('keeps manual-review matches in the original unknown bucket', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'unverified fund', company_name: 'Unverified fund', dividend_amount: 500, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        'UNVERIFIED FUND': {
+          source_input: 'UNVERIFIED FUND',
+          matched_ticker: 'MSFT',
+          matched_company_name: 'Possible match',
+          status: 'manual_review',
+          confidence: 'low',
+          evidence: 'Name similarity only',
+        },
+      },
+      tickersMap: {
+        MSFT: { ticker: 'MSFT', sector: 'Technology', industry: 'Software' },
+      },
+    });
+
+    expect(result.unknownItems).toEqual([
+      expect.objectContaining({
+        ticker: 'UNVERIFIED FUND',
+        sourceInput: 'unverified fund',
+        amount: 500,
+        matchStatus: 'manual_review',
+        confidence: 'low',
+      }),
+    ]);
+    expect(result.sectorTableData[0].ticker).toBe('UNVERIFIED FUND');
+    expect(result.sectorTableData[0].sector).toBe('Unknown');
+  });
+});

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -70,4 +70,26 @@ describe('buildPortfolioSummary', () => {
     expect(result.sectorTableData[0].ticker).toBe('UNVERIFIED FUND');
     expect(result.sectorTableData[0].sector).toBe('Unknown');
   });
+
+  test('does not classify manual-review input from existing ticker metadata', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'AMBIGUOUS', company_name: 'Ambiguous', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        AMBIGUOUS: {
+          status: 'manual_review',
+          matched_ticker: 'AMBIGUOUS',
+          confidence: 'medium',
+          evidence: 'Needs confirmation',
+        },
+      },
+      tickersMap: {
+        AMBIGUOUS: { ticker: 'AMBIGUOUS', sector: 'Should remain hidden', industry: 'Should remain hidden' },
+      },
+    });
+
+    expect(result.unknownItems).toEqual([
+      expect.objectContaining({ ticker: 'AMBIGUOUS', sector: 'Unknown', industry: '-' }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- Add an evidence-backed `ticker_matches` migration for 37 unclassified input groups: 25 confirmed and 12 retained for manual review.
- Preserve original dividend entries and keep incomplete, ambiguous, historical, and colliding aliases quarantined.
- Apply only complete high-confidence matches to search choices, portfolio classification, and dividend aggregation.
- Document migration order, evidence fields, confidence rules, and fail-closed alias behavior.

## Verification

- `CI=true npm test -- --watchAll=false --runInBand` (6 suites, 26 tests)
- `npm run build`
- Targeted adversarial/UI tests (14 tests)
- Wiki link/index/orphan/source-reference lint
- Static migration seed and secret/PII checks
- Authenticated Supabase/RLS and post-login UI could not be run locally because no test environment credentials are available.

Closes #18