### PR TITLE
fix(portfolio): show verified company names in contribution table

### DIFF
--- a/llm-wiki/wiki/architecture.md
+++ b/llm-wiki/wiki/architecture.md
@@ -31,7 +31,7 @@ React screens --> Supabase client --> Auth + PostgreSQL/RLS
 
 - [`useDividendData.js`](../../src/hooks/useDividendData.js): `dividend_entries`, `tickers`, `ticker_matches`를 조회하고 USD/KRW 환율을 결합한다.
 - [`DividendData.jsx`](../../src/components/DividendData.jsx): count를 포함한 server-side pagination query를 수행한다.
-- Dashboard, calendar, portfolio, notifications는 배당 데이터를 목적별로 재구성한다.
+- Dashboard, calendar, portfolio, notifications는 배당 데이터를 목적별로 재구성한다. Portfolio의 종목별 기여도 표는 `confirmed` 매칭의 검증된 실제 종목명을 우선 표시하고, 미확인 항목은 원본 입력값과 확인 대기 상태를 표시한다.
 - Goal과 simulator는 각각 `user_goals`, `simulation_settings`를 현재 user ID로 조회한다.
 
 ## Write paths

--- a/llm-wiki/wiki/log.md
+++ b/llm-wiki/wiki/log.md
@@ -107,6 +107,12 @@
 - 기존 `dividend_entries`는 수정하지 않는다.
 - 근거: [`database/ticker_matching.sql`](../../database/ticker_matching.sql), [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js), [`PortfolioAnalysis.jsx`](../../src/components/PortfolioAnalysis.jsx)
 
+## [2026-08-16] fix | 종목별 기여도 표의 종목명 표시
+
+- `confirmed` 매칭은 검증된 실제 종목명을 우선 표시하고, 미확인 항목은 원본 입력값과 확인 대기 상태를 표시하도록 했다.
+- 확정 항목의 canonical ticker는 보조 텍스트로 유지하고 긴 종목명은 표 셀 안에서 줄바꿈한다.
+- 근거: [`PortfolioAnalysis.jsx`](../../src/components/PortfolioAnalysis.jsx), [`src/utils/tickerMatching.js`](../../src/utils/tickerMatching.js)
+
 ## [2026-08-16] lint | 원본 보존형 종목 매칭 Wiki 무결성
 
 - 9개 Wiki 페이지의 index 등록, inbound link, 상대 링크, frontmatter, `Sources`, `Related`, source reference를 검사했다.

--- a/src/components/PortfolioAnalysis.jsx
+++ b/src/components/PortfolioAnalysis.jsx
@@ -3,7 +3,7 @@ import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Doughnut } from 'react-chartjs-2';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { useDividendData } from '../hooks/useDividendData';
-import { buildPortfolioSummary, MATCH_STATUS } from '../utils/tickerMatching';
+import { buildPortfolioSummary, getPortfolioDisplayName, MATCH_STATUS } from '../utils/tickerMatching';
 import { PieChart, AlertCircle, X } from 'lucide-react';
 import { supabase } from '../api/supabaseClient';
 
@@ -229,8 +229,8 @@ function PortfolioAnalysis() {
             {/* Top 20 Table */}
             <div className="card">
                 <h4>종목별 기여도 Top 20</h4>
-                <div style={{ overflowX: 'auto' }}>
-                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+                <div className="portfolio-table-scroll" style={{ overflowX: 'auto' }}>
+                    <table className="portfolio-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
                         <thead>
                             <tr style={{ borderBottom: '2px solid var(--border-color)', textAlign: 'left' }}>
                                 <th style={{ padding: '12px' }}>종목</th>
@@ -244,9 +244,16 @@ function PortfolioAnalysis() {
                             {sectorTableData.slice(0, 20).map((row, idx) => {
                                 const total = sectorTableData.reduce((sum, r) => sum + r.amount, 0);
                                 const percent = ((row.amount / total) * 100).toFixed(1);
+                                const displayName = getPortfolioDisplayName(row);
+                                const displayTicker = row.isConfirmed ? row.ticker : '';
                                 return (
                                     <tr key={idx} style={{ borderBottom: '1px solid var(--border-color)' }}>
-                                        <td style={{ padding: '12px', fontWeight: 'bold' }}>{row.ticker}</td>
+                                        <td className="portfolio-security-cell" style={{ padding: '12px', fontWeight: 'bold' }}>
+                                            <span className="portfolio-security-name">{displayName}</span>
+                                            {displayTicker && displayTicker !== displayName && (
+                                                <small className="portfolio-security-ticker">{displayTicker}</small>
+                                            )}
+                                        </td>
                                         <td style={{ padding: '12px' }}>
                                             <span style={{
                                                 padding: '2px 8px', borderRadius: '12px',
@@ -274,8 +281,8 @@ function PortfolioAnalysis() {
                         <AlertCircle color="#e74a3b" size={20} />
                         <h4 style={{ margin: 0, color: '#e74a3b' }}>분류 미확인 종목 정보 보완</h4>
                     </div>
-                    <div style={{ overflowX: 'auto' }}>
-                        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+                    <div className="portfolio-table-scroll" style={{ overflowX: 'auto' }}>
+                        <table className="portfolio-table" style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
                             <thead>
                                 <tr style={{ borderBottom: '2px solid var(--border-color)', textAlign: 'left' }}>
                                     <th style={{ padding: '12px' }}>원본 입력값</th>

--- a/src/components/PortfolioAnalysis.test.jsx
+++ b/src/components/PortfolioAnalysis.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import PortfolioAnalysis from './PortfolioAnalysis';
+
+jest.mock('chart.js', () => ({
+  Chart: { register: jest.fn() },
+  ArcElement: jest.fn(),
+  Legend: jest.fn(),
+  Tooltip: jest.fn()
+}));
+
+jest.mock('chartjs-plugin-datalabels', () => ({}));
+
+jest.mock('react-chartjs-2', () => ({
+  Doughnut: () => <div>Doughnut Chart Mock</div>
+}));
+
+jest.mock('../api/supabaseClient', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+jest.mock('../hooks/useDividendData', () => ({
+  __esModule: true,
+  useDividendData: () => ({
+    data: [
+      { ticker: 'LEGACY FUND', dividend_amount: 100, currency: 'KRW' },
+      { ticker: 'UNVERIFIED FUND', dividend_amount: 50, currency: 'KRW' },
+      { ticker: 'LEGACY', company_name: 'Legacy', dividend_amount: 25, currency: 'KRW' }
+    ],
+    exchangeRate: 1300,
+    loading: false,
+    tickerMatchesMap: {
+      'LEGACY FUND': {
+        status: 'confirmed',
+        confidence: 'high',
+        matched_ticker: 'AAPL',
+        matched_company_name: 'Apple Inc.',
+        market: 'NASDAQ',
+        sector: 'Technology',
+        industry: 'Consumer Electronics',
+        evidence: 'Issuer verified'
+      },
+      'UNVERIFIED FUND': {
+        status: 'manual_review',
+        confidence: 'low',
+        matched_ticker: 'MSFT',
+        matched_company_name: 'Possible match',
+        evidence: 'Name similarity only'
+      },
+      LEGACY: {
+        status: 'confirmed',
+        confidence: 'high',
+        matched_ticker: 'AAPL',
+        evidence: ''
+      }
+    },
+    tickersMap: {}
+  })
+}));
+
+test('renders verified names and keeps unconfirmed candidates out of the contribution table', () => {
+  render(<PortfolioAnalysis />);
+
+  const contributionTable = screen.getAllByRole('table')[0];
+  const contributionTableView = within(contributionTable);
+
+  expect(contributionTableView.getByText('Apple Inc.')).toBeInTheDocument();
+  expect(contributionTableView.getByText('AAPL')).toBeInTheDocument();
+  expect(contributionTableView.getByText('UNVERIFIED FUND (확인 대기)')).toBeInTheDocument();
+  expect(contributionTableView.getByText('LEGACY (확인 대기)')).toBeInTheDocument();
+  expect(contributionTableView.queryByText('Possible match')).not.toBeInTheDocument();
+  expect(contributionTableView.getByText('UNVERIFIED FUND (확인 대기)')).toHaveClass('portfolio-security-name');
+});

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -52,6 +52,37 @@ body {
   border: 1px solid var(--border-color);
 }
 
+.portfolio-table {
+  min-width: 720px;
+}
+
+.portfolio-table th,
+.portfolio-table td {
+  word-break: keep-all;
+}
+
+.portfolio-security-cell {
+  max-width: 220px;
+  min-width: 150px;
+  width: 220px;
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}
+
+.portfolio-security-name,
+.portfolio-security-ticker {
+  display: block;
+  overflow-wrap: break-word;
+  word-break: keep-all;
+}
+
+.portfolio-security-ticker {
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: normal;
+  margin-top: 4px;
+}
+
 /* Form Elements */
 input, select, textarea {
   background-color: var(--bg-secondary);

--- a/src/utils/tickerMatching.js
+++ b/src/utils/tickerMatching.js
@@ -45,6 +45,16 @@ export function buildTickerMatchesMap(matches) {
   return matchMap;
 }
 
+export function getPortfolioDisplayName(row) {
+  const companyName = String(row?.companyName ?? '').trim();
+  if (row?.isConfirmed === true && companyName) return companyName;
+
+  const sourceInput = String(row?.sourceInput ?? '').trim();
+  const ticker = normalizeTickerInput(row?.ticker);
+  const fallback = sourceInput || ticker;
+  return fallback ? `${fallback} (확인 대기)` : '종목명 확인 대기';
+}
+
 function getBlockedSourceKeys(tickerMatchesMap) {
   return tickerMatchesMap?.__blockedSourceKeys instanceof Set
     ? tickerMatchesMap.__blockedSourceKeys
@@ -164,6 +174,7 @@ export function buildPortfolioSummary({ data, tickerMatchesMap, tickersMap, exch
         ticker,
         amount,
         companyName,
+        isConfirmed: resolution.isConfirmed,
         sector,
         industry,
         market: resolution.isBlocked

--- a/src/utils/tickerMatching.test.js
+++ b/src/utils/tickerMatching.test.js
@@ -1,4 +1,4 @@
-import { buildPortfolioSummary, buildTickerMatchesMap } from './tickerMatching';
+import { buildPortfolioSummary, buildTickerMatchesMap, getPortfolioDisplayName } from './tickerMatching';
 
 describe('buildPortfolioSummary', () => {
   test('fails closed when normalized source aliases collide', () => {
@@ -271,6 +271,7 @@ describe('buildPortfolioSummary', () => {
     expect(result.unknownItems).toEqual([
       expect.objectContaining({ ticker: 'LEGACY', sector: 'Unknown', matchStatus: 'confirmed' }),
     ]);
+    expect(getPortfolioDisplayName(result.sectorTableData[0])).toBe('LEGACY (확인 대기)');
   });
 
   test('ignores incomplete confirmed aliases when resolving a verified alias', () => {
@@ -331,5 +332,48 @@ describe('buildPortfolioSummary', () => {
       expect.objectContaining({ ticker: 'AAPL', amount: 50, sector: 'Unknown', matchStatus: 'manual_review' }),
     ]));
     expect(result.unknownItems).toHaveLength(1);
+  });
+
+  test('displays the verified company name before its canonical ticker', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'LEGACY FUND', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        'LEGACY FUND': {
+          status: 'confirmed',
+          confidence: 'high',
+          matched_ticker: 'AAPL',
+          matched_company_name: 'Apple Inc.',
+          market: 'NASDAQ',
+          sector: 'Technology',
+          industry: 'Consumer Electronics',
+          evidence: 'Issuer verified',
+        },
+      },
+      tickersMap: {},
+    });
+
+    expect(getPortfolioDisplayName(result.sectorTableData[0])).toBe('Apple Inc.');
+    expect(result.sectorTableData[0].ticker).toBe('AAPL');
+  });
+
+  test('keeps an unconfirmed input visible without presenting its candidate as verified', () => {
+    const result = buildPortfolioSummary({
+      data: [{ ticker: 'UNVERIFIED FUND', dividend_amount: 100, currency: 'KRW' }],
+      exchangeRate: 1300,
+      tickerMatchesMap: {
+        'UNVERIFIED FUND': {
+          status: 'manual_review',
+          confidence: 'low',
+          matched_ticker: 'MSFT',
+          matched_company_name: 'Possible match',
+          evidence: 'Name similarity only',
+        },
+      },
+      tickersMap: {},
+    });
+
+    expect(getPortfolioDisplayName(result.sectorTableData[0])).toBe('UNVERIFIED FUND (확인 대기)');
+    expect(getPortfolioDisplayName({ ticker: '', sourceInput: '' })).toBe('종목명 확인 대기');
   });
 });


### PR DESCRIPTION
## Summary
- show verified company names in the Portfolio contribution table
- keep unverified and incomplete matches on the original input with an explicit pending label
- preserve canonical tickers as secondary text and make both tables mobile-scrollable with CJK-safe wrapping

## Why
The contribution table rendered canonical or source tickers directly, making confirmed holdings harder to identify and allowing pending candidates to appear ambiguous.

## Impact
Only presentation and display metadata changed. Sector, industry, amount, and percentage aggregation remain unchanged.

## Verification
- `CI=true npm test -- --watchAll=false --runInBand`
- `npm run build`
- Fresh browser QA at 1280x800 and 375x812 using the built PortfolioAnalysis render
- Final independent visual QA: PASS

Closes #24